### PR TITLE
fix(editor/collab): #197 + #198 + resolve the collab data-loss saga (dual yjs instance on the WS server)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,4 +94,11 @@ docker compose -f compose.dev.yaml restart websocket   # e.g. to test reconnects
 - The collaborative editor is the most sensitive subsystem and **now has test
   coverage** (added under #202 / PR #203). Read
   `web/gl-admin/lib/collaboration/CLAUDE.md` before touching it.
+- **The 2026-06 collab data-loss saga is RESOLVED** (PR #204): a stack of five real
+  bugs, the decisive one being a **dual yjs instance (ESM+CJS double-load) inside the
+  websocket server** — `npm ls` showed one deduped copy, but the ESM `import` and
+  y-websocket's CJS `require` each evaluated their own build, and cross-instance
+  `Y.applyUpdate` corrupted live docs. Details + guards: `websocket/CLAUDE.md` (top
+  gotcha) and `web/gl-admin/lib/collaboration/CLAUDE.md` (hard rules 0–8). `yjs` is
+  pinned `13.6.31` exact in BOTH `web/` and `websocket/` — keep them in lockstep.
 </content>

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -40,8 +40,14 @@ the codebase. **Before editing anything under `gl-admin/components/editor/` or
 - TipTap is on **v3** (breaking from v2). `setContent`'s 2nd arg is an options object
   `{ emitUpdate }` — NOT the v2 boolean. `emitUpdate:false` only suppresses TipTap's
   `update` event; the collaboration ySyncPlugin still mirrors content to Yjs regardless.
-- StarterKit ships its own history → it conflicts with `@tiptap/extension-collaboration`
-  (a console warning). Disable StarterKit history when collab is on (open follow-up).
+- StarterKit's bundled undo/redo is **disabled when collaborating** (`undoRedo:
+  collabProvider ? false : undefined` in `editor/utils/extensions.ts`, #197) —
+  Collaboration ships its own Yjs-aware history. Keep it for non-collab editors.
+- **`yjs` is pinned to `13.6.31` (exact, no `^`) and must match `websocket/`'s pin.**
+  The two packages have separate lockfiles; loose ranges drifted apart once and
+  contributed to collab data corruption. See
+  `gl-admin/lib/collaboration/CLAUDE.md` rule 8 and `websocket/CLAUDE.md`'s top gotcha
+  (dual ESM/CJS instance) before touching any yjs-family dependency.
 - The admin Content list route `/content/:typeName` keys its component by `typeName`
   (`ContentByType` in `app.tsx`) so switching post types remounts + refetches.
 </content>

--- a/web/gl-admin/components/editor/Editor.tsx
+++ b/web/gl-admin/components/editor/Editor.tsx
@@ -42,7 +42,7 @@ export interface EditorRef {
   getSaveStatus: () => { isSaving: boolean; isPublishing: boolean; saveStatus: "saved" | "saving" | "error" | null }
 }
 
-export default forwardRef<EditorRef, Props>(function Editor(
+const EditorInner = forwardRef<EditorRef, Props>(function EditorInner(
   {
     value,
     onChange,
@@ -455,4 +455,30 @@ export default forwardRef<EditorRef, Props>(function Editor(
       <CharacterCount editor={editor} minChars={minChars} maxChars={maxChars} />
     </div>
   )
+})
+
+// Theme gate: only mount the editor once the theme (and its TipTap block/extension
+// registry) has loaded, so the editor is created exactly ONCE with the full extension
+// set. Previously the editor was built with base extensions before the theme loaded and
+// then recreated when `isThemeLoaded` flipped (extensions + collabProvider are in the
+// useEditor deps), causing a double create in production (#198). This must be a separate
+// wrapper component — an early return before `useEditor` inside EditorInner would change
+// the hook count between renders and violate the Rules of Hooks.
+export default forwardRef<EditorRef, Props>(function Editor(props, ref) {
+  const { isThemeLoaded } = useTheme()
+
+  if (!isThemeLoaded) {
+    return (
+      <div className="notion-editor">
+        <div
+          className="editor-wrapper"
+          style={{ display: "flex", alignItems: "center", justifyContent: "center", minHeight: "200px" }}
+        >
+          <p style={{ color: "#999" }}>Loading theme…</p>
+        </div>
+      </div>
+    )
+  }
+
+  return <EditorInner ref={ref} {...props} />
 })

--- a/web/gl-admin/components/editor/Editor.tsx
+++ b/web/gl-admin/components/editor/Editor.tsx
@@ -301,12 +301,11 @@ const EditorInner = forwardRef<EditorRef, Props>(function EditorInner(
       hasInitializedRef.current = true
       if (import.meta.env.DEV) console.debug("[Editor] onSynced — running one-time content load")
 
-      // Wait for IndexedDB to finish its initial load before deciding whether to seed.
-      // On the WS "synced" tick IndexedDB may not have applied yet, so the editor can
-      // look empty even though it has cached content. Seeding then would mint fresh Yjs
-      // structs that collide with IndexedDB's once it loads — diverging the doc (spurious
-      // saves, content/image erased, worse on every reload). After this await the
-      // emptiness checks below reflect the real, fully-restored state.
+      // There is no longer a client-side IndexedDB cache; the WS "synced" event we are
+      // inside is the single signal that the server's authoritative Yjs state has loaded
+      // into the doc. So `whenSynced` resolves immediately and the emptiness checks below
+      // reflect the real, fully-restored state — we only seed from the REST working copy
+      // when the server genuinely has nothing. (await kept for API symmetry / future use.)
       try {
         await collabProvider.whenSynced
       } catch {

--- a/web/gl-admin/components/editor/Editor.tsx
+++ b/web/gl-admin/components/editor/Editor.tsx
@@ -288,7 +288,7 @@ const EditorInner = forwardRef<EditorRef, Props>(function EditorInner(
   // Collaboration content sync
   useEffect(() => {
     if (!editor || !collabProvider) return
-    const onSynced = (isSynced: boolean) => {
+    const onSynced = async (isSynced: boolean) => {
       if (!isSynced) return
 
       // Run the initial-content load only once for this editor instance.
@@ -301,7 +301,20 @@ const EditorInner = forwardRef<EditorRef, Props>(function EditorInner(
       hasInitializedRef.current = true
       if (import.meta.env.DEV) console.debug("[Editor] onSynced — running one-time content load")
 
-      const frag = collabProvider.doc.getXmlFragment("prosemirror")
+      // Wait for IndexedDB to finish its initial load before deciding whether to seed.
+      // On the WS "synced" tick IndexedDB may not have applied yet, so the editor can
+      // look empty even though it has cached content. Seeding then would mint fresh Yjs
+      // structs that collide with IndexedDB's once it loads — diverging the doc (spurious
+      // saves, content/image erased, worse on every reload). After this await the
+      // emptiness checks below reflect the real, fully-restored state.
+      try {
+        await collabProvider.whenSynced
+      } catch {
+        /* ignore — proceed with whatever state we have */
+      }
+      if (editor.isDestroyed) return
+
+      const frag = collabProvider.doc.getXmlFragment("default")
       const emptyShared = frag.length === 0
       const emptyLocal = editor.isEmpty
 

--- a/web/gl-admin/components/editor/extensions/BlockIdExtension.ts
+++ b/web/gl-admin/components/editor/extensions/BlockIdExtension.ts
@@ -50,18 +50,29 @@ export const BlockIdExtension = Extension.create({
           let tr = newState.tr
           let hasChanges = false
 
-          let pos = 0
-          newState.doc.content.forEach((node, offset, index) => {
-            const currentId = node.attrs["data-block-id"]
+          // Track ids already seen in THIS pass so we can regenerate DUPLICATES, not
+          // just missing/too-short ids. Splitting a block (pressing Enter) copies the
+          // origin node's attributes — including data-block-id — onto the new node, so a
+          // single keystroke silently mints a duplicate id. Duplicates are corrupting: the
+          // block_doc `blocks` map is keyed by id, so two blocks sharing an id collapse to
+          // one (the other is lost) on every save, and any id-based reconciliation then
+          // fights itself. The old guard (`!currentId || length < 10`) never caught this.
+          const seenIds = new Set<string>()
 
-            // Only assign ID if node doesn't have a valid one
-            if (!currentId || typeof currentId !== "string" || currentId.length < 10) {
-              // Generate a truly unique ID for new nodes
+          let pos = 0
+          newState.doc.content.forEach((node) => {
+            const currentId = node.attrs["data-block-id"]
+            const invalid = !currentId || typeof currentId !== "string" || currentId.length < 10
+            const duplicate = !invalid && seenIds.has(currentId as string)
+
+            if (invalid || duplicate) {
               const newId = generateBlockId()
               const attrs = { ...node.attrs, "data-block-id": newId }
-
               tr = tr.setNodeMarkup(pos, node.type, attrs, node.marks)
               hasChanges = true
+              seenIds.add(newId)
+            } else {
+              seenIds.add(currentId as string)
             }
 
             pos += node.nodeSize

--- a/web/gl-admin/components/editor/extensions/BlockIdExtension.ts
+++ b/web/gl-admin/components/editor/extensions/BlockIdExtension.ts
@@ -1,5 +1,6 @@
 import { Extension } from "@tiptap/core"
 import { Plugin, PluginKey } from "prosemirror-state"
+import { isChangeOrigin } from "@tiptap/extension-collaboration"
 
 const blockIdPluginKey = new PluginKey("blockId")
 
@@ -31,6 +32,20 @@ export const BlockIdExtension = Extension.create({
         appendTransaction(transactions, oldState, newState) {
           const docChanged = transactions.some((tr) => tr.docChanged)
           if (!docChanged) return null
+
+          // CRITICAL (collab): never assign block IDs in response to a change that came
+          // from the collaboration sync (a remote Yjs update applied by ySyncPlugin).
+          // crypto.randomUUID() produces a different id every call, so reacting to a
+          // remote update by minting a new id is a *new local* transaction that mirrors
+          // straight back into Yjs and is sent to the server; the next 2s resync delivers
+          // the server's version again, we mint again, forever. That feedback loop is the
+          // "heartbeat" — the editor and server ping-pong (PluginKey ↔ WebsocketProvider),
+          // never converge, and the delete-war erases the user's text and images. Block
+          // IDs for remote content arrive over the wire as synced node attributes; only
+          // the client that ORIGINATES a node needs to assign one, and pmToBlockDoc
+          // backfills any still-missing id at save time. isChangeOrigin() is TipTap's
+          // official "did this transaction come from Yjs?" check.
+          if (transactions.some((tr) => isChangeOrigin(tr))) return null
 
           let tr = newState.tr
           let hasChanges = false

--- a/web/gl-admin/components/editor/utils/extensions.ts
+++ b/web/gl-admin/components/editor/utils/extensions.ts
@@ -40,6 +40,12 @@ const extensions = ({ collabProvider, maxChars, placeholder, setUrl, setIsLinkMo
         codeBlock: false,
         dropcursor: { width: 2, color: "var(--editor-cursor,#3b82f6)" },
         link: false,
+        // Collaboration ships its own Yjs-aware undo/redo (with Mod-z / Mod-y /
+        // Shift-Mod-z keymaps). Disable StarterKit's bundled undoRedo when collaborating
+        // to resolve the "@tiptap/extension-collaboration … not compatible with
+        // @tiptap/extension-undo-redo" conflict; keep it for non-collab editors where
+        // it's the only undo stack.
+        undoRedo: collabProvider ? false : undefined,
       }),
       CodeBlockLowlight.configure({
         lowlight,

--- a/web/gl-admin/lib/collaboration/BlockPersistenceManager.test.ts
+++ b/web/gl-admin/lib/collaboration/BlockPersistenceManager.test.ts
@@ -118,6 +118,46 @@ describe("initialize()", () => {
   })
 })
 
+describe("warm reload — does not overwrite an already-populated Yjs doc", () => {
+  it("keeps live Yjs content and ignores the REST working copy when the doc is non-empty", async () => {
+    // Simulate a warm reload: IndexedDB + the WS server have already restored content
+    // into the collaborative doc BEFORE the REST load runs.
+    const blockDocManager = new BlockDocManager(new Y.Doc())
+    blockDocManager.setBlockDocV1(oneBlockDoc("live-yjs-content"))
+
+    const manager = new BlockPersistenceManager(1, blockDocManager, "tok")
+    manager.setSyncCallback(vi.fn())
+
+    // The REST working copy returns DIFFERENT (older) content.
+    api.getPostBlocks.mockResolvedValueOnce({ doc: oneBlockDoc("stale-rest-content"), revision: 3 })
+    await manager.initialize()
+    await vi.advanceTimersByTimeAsync(500)
+
+    // The live Yjs content must be preserved — overwriting it via setBlockDocV1/
+    // setContent is what caused the reload "heartbeat" (a competing parallel state
+    // the resync then fights). Revision is still adopted from the load.
+    const after = blockDocManager.getBlockDocV1()
+    const texts = after.blocks_order.map((bid) => (after.blocks[bid].attrs as { text?: string }).text)
+    expect(texts).toContain("live-yjs-content")
+    expect(texts).not.toContain("stale-rest-content")
+    expect(manager.getCurrentRevision()).toBe(3)
+  })
+
+  it("DOES seed from REST when the Yjs doc is empty (cold start)", async () => {
+    const blockDocManager = new BlockDocManager(new Y.Doc()) // empty
+    const manager = new BlockPersistenceManager(1, blockDocManager, "tok")
+    manager.setSyncCallback(vi.fn())
+
+    api.getPostBlocks.mockResolvedValueOnce({ doc: oneBlockDoc("rest-content"), revision: 1 })
+    await manager.initialize()
+    await vi.advanceTimersByTimeAsync(500)
+
+    const after = blockDocManager.getBlockDocV1()
+    const texts = after.blocks_order.map((bid) => (after.blocks[bid].attrs as { text?: string }).text)
+    expect(texts).toContain("rest-content")
+  })
+})
+
 describe("autosave", () => {
   it("debounced edit triggers a save with the current doc", async () => {
     const { manager } = makeManager()

--- a/web/gl-admin/lib/collaboration/BlockPersistenceManager.test.ts
+++ b/web/gl-admin/lib/collaboration/BlockPersistenceManager.test.ts
@@ -312,6 +312,28 @@ describe("no echo loop on reconnect (WS-restart heartbeat)", () => {
 
     expect(api.updatePostBlocks).not.toHaveBeenCalled()
   })
+
+  it("REPEATED server echoes (the 2s resync) never trigger autosaves", async () => {
+    // The actual heartbeat: after a WS restart the server reflected a blocks-map update
+    // back to the client on every ~2s resync. With a doc-map autosave trigger, each echo
+    // scheduled a save → PUT every ~2s, revision climbing, content erased. Model many
+    // echoes over time and assert ZERO saves — the only legitimate autosave trigger is a
+    // real editor edit (notifyEditorChange).
+    const { manager, blockDocManager } = makeManager()
+    await activate(manager)
+    api.updatePostBlocks.mockClear()
+
+    for (let i = 0; i < 6; i++) {
+      blockDocManager.insertBlockAtPosition(
+        { id: id(), type: "paragraph", version: 1, attrs: { text: `echo-${i}` } },
+        0
+      )
+      await vi.advanceTimersByTimeAsync(2000) // one resync interval
+    }
+
+    expect(api.updatePostBlocks).not.toHaveBeenCalled()
+    expect(manager.hasUnsaved()).toBe(false)
+  })
 })
 
 describe("publish()", () => {

--- a/web/gl-admin/lib/collaboration/BlockPersistenceManager.ts
+++ b/web/gl-admin/lib/collaboration/BlockPersistenceManager.ts
@@ -141,17 +141,29 @@ export class BlockPersistenceManager {
       const { doc, revision } = await blockAPIClient.getPostBlocks(this.postId)
       this.currentRevision = revision
 
-      // Only set if the document is not empty (has actual content)
+      // Seed from the REST working copy ONLY when the live Yjs doc is empty (a cold
+      // start: no IndexedDB cache and an empty WS/LevelDB doc). When the collaborative
+      // doc has already been restored with content (a warm reload — IndexedDB + the WS
+      // server repopulate it, and the Collaboration plugin shows it), Yjs is the source
+      // of truth. Overwriting it here is the bug behind the reload "heartbeat":
+      // setContent(blockDocToPM(doc)) becomes delete-all + insert-new on the
+      // already-populated prosemirror fragment via ySyncPlugin, creating a competing
+      // parallel state that the 2s resync then fights, reverting the user's content.
+      // So we seed only the side(s) that are actually empty.
       if (doc.blocks_order.length > 0 || Object.keys(doc.blocks).length > 0) {
-        // Update Y.js BlockDoc
-        this.blockDocManager.setBlockDocV1(doc)
+        const current = this.blockDocManager.getBlockDocV1()
+        const blocksAlreadyPopulated =
+          current.blocks_order.length > 0 || Object.keys(current.blocks).length > 0
+        const editorAlreadyPopulated = !!this.editor && !this.editor.isDestroyed && !this.editor.isEmpty
 
-        // If we have an editor, convert and apply to editor state.
-        // emitUpdate:false suppresses TipTap's "update" event for this programmatic
-        // load (so it doesn't look like a user edit / trigger autosave). The content
-        // still syncs into the Yjs "prosemirror" fragment because the collaboration
-        // ySyncPlugin mirrors the transaction regardless of the emitUpdate flag.
-        if (this.editor && !this.editor.isDestroyed) {
+        if (!blocksAlreadyPopulated) {
+          this.blockDocManager.setBlockDocV1(doc)
+        }
+
+        if (this.editor && !this.editor.isDestroyed && !editorAlreadyPopulated) {
+          // emitUpdate:false suppresses TipTap's "update" event for this programmatic
+          // seed. The content still syncs into the Yjs "prosemirror" fragment because
+          // the collaboration ySyncPlugin mirrors the transaction regardless of the flag.
           try {
             const pmDoc = blockDocToPM(doc, this.editor.schema)
             this.editor.commands.setContent(pmDoc.toJSON(), { emitUpdate: false })

--- a/web/gl-admin/lib/collaboration/CLAUDE.md
+++ b/web/gl-admin/lib/collaboration/CLAUDE.md
@@ -87,6 +87,18 @@ A change in (1) only reaches (2) when something **mirrors** it (`pmToBlockDoc` �
    re-fires on every reconnect; without the guard, reconnects re-run `setContent` and
    clobber in-progress typing. The persistence manager has its own `hasInitialized`.
 
+7. **Editor plugins with `appendTransaction` (or `filterTransaction`) MUST ignore
+   collaboration-sync transactions.** `components/editor/extensions/BlockIdExtension.ts`
+   assigns `data-block-id`s; it ran on *every* `docChanged`, including the transactions
+   `ySyncPlugin` dispatches for **remote** Yjs updates, and minted a fresh
+   `crypto.randomUUID()` each time. That made a sync→appendTransaction→sync feedback loop
+   (random ids never converge) — a primary driver of the "heartbeat" content/image
+   erasure, distinct from rule 0. Guard with TipTap's `isChangeOrigin(tr)` (from
+   `@tiptap/extension-collaboration`): `if (transactions.some(tr => isChangeOrigin(tr)))
+   return null`. Only the client that originates a node assigns its id; remote ids arrive
+   as synced attributes and `pmToBlockDoc` backfills any missing at save time. Any future
+   doc-mutating plugin must do the same.
+
 ## State machine flags (BlockPersistenceManager)
 
 `isInitializing` (load latch, cleared 500ms after init in `finally`) · `isSaving`

--- a/web/gl-admin/lib/collaboration/CLAUDE.md
+++ b/web/gl-admin/lib/collaboration/CLAUDE.md
@@ -20,9 +20,11 @@ A change in (1) only reaches (2) when something **mirrors** it (`pmToBlockDoc` �
 ## Files
 
 - `CollaborationProvider.ts` — per-post singleton: `Y.Doc` + `WebsocketProvider`
-  (`ws://…:1234`, `resyncInterval: 2000`) + `IndexeddbPersistence` (`post-<id>`).
-  Ref-counted; destroyed 750ms after last release. **`resyncInterval: 2000` = the "2s"
-  cadence** you'll see in any heartbeat-style bug.
+  (`ws://…:1234`, `resyncInterval: 2000`). Ref-counted; destroyed 750ms after last
+  release. **`resyncInterval: 2000` = the "2s" cadence** you'll see in any heartbeat-style
+  bug. **NO client-side `IndexeddbPersistence`** — it was removed deliberately (see rule
+  0). The WS server's LevelDB is the single live Yjs store; `whenSynced` is now a resolved
+  promise kept only for API symmetry.
 - `BlockDocManager.ts` — CRUD over the `blocks`/`blocks_order` maps. `setBlockDocV1` is
   **incremental** (diff/upsert) — see below.
 - `BlockPersistenceManager.ts` — the autosave **state machine**. The brains; most
@@ -32,6 +34,15 @@ A change in (1) only reaches (2) when something **mirrors** it (`pmToBlockDoc` �
   Server side: `COLLAB_DEBUG=1`. Both are timestamped (`t=…`) so client+server logs align.
 
 ## Hard rules (violating these reintroduces shipped bugs)
+
+0. **Do NOT reintroduce client-side `IndexeddbPersistence` (or any client cache that
+   survives reloads).** The WS server (LevelDB) is the **single source of truth** for the
+   live Yjs state; Postgres `posts.block_doc` is the durable backup. A local Yjs cache
+   inevitably builds a *different struct history* for the same content than the server's
+   rebuilt doc; the two never converge, the 2s resync keeps applying "differences" (each a
+   PM transaction → a spurious autosave with no typing), and it **compounds every reload**
+   (the recurring "heartbeat" that erased text/images and "got worse each reload"). On
+   open, the editor loads purely from the server. Removed in the IndexedDB-removal commit.
 
 1. **Autosave is driven ONLY by `notifyEditorChange()`** (called from
    `editor.on("update")` in `Editor.tsx`). **Do NOT subscribe an autosave trigger to
@@ -51,14 +62,17 @@ A change in (1) only reaches (2) when something **mirrors** it (`pmToBlockDoc` �
    after a successful load and releases `isInitializing` in a `finally`. A failed load
    (e.g. 401) must remain retryable and must NOT permanently disable autosave.
 
-3b. **Seed the editor from the REST working copy ONLY when the live Yjs doc is empty.**
-   On a warm reload, IndexedDB + the WS server restore the prosemirror fragment and the
-   blocks maps — Yjs is the source of truth and the Collaboration plugin already shows
-   the content. `initialize()` must NOT `setContent`/`setBlockDocV1` over a non-empty
-   Yjs doc: `setContent` becomes delete-all + insert-new on the fragment (via ySyncPlugin),
-   creating a competing parallel state the 2s resync then fights — reverting the user's
-   content (the reload "heartbeat", reproducible via Ctrl+S then reload). Guard with
-   `!editor.isEmpty` / a non-empty `getBlockDocV1()`; only seed the side(s) that are empty.
+3b. **Seed the editor from the REST working copy ONLY when the live Yjs doc is empty,
+   and ONLY after the WS `synced` event.** On a warm reload the WS server restores the
+   prosemirror fragment — Yjs is the source of truth and the Collaboration plugin already
+   shows the content. The seed runs inside `onSynced` (Editor.tsx) so the authoritative
+   server state has loaded before we test emptiness; seeding earlier (e.g. from
+   `initialize()` before WS sync) would mint fresh structs that then collide with the
+   server's on sync — the same divergence as rule 0. `setContent` over a non-empty doc
+   becomes delete-all + insert-new on the fragment (via ySyncPlugin), creating a competing
+   parallel state the 2s resync fights — reverting the user's content (the reload
+   "heartbeat", reproducible via Ctrl+S then reload). Guard with `!editor.isEmpty` /
+   `emptyShared`; only seed when the server genuinely has nothing.
 
 4. **`saveTimer` must be nulled when the debounce timer fires** (inside the
    `setTimeout` callback). The missed-timer recovery in `performSave`'s `finally` checks

--- a/web/gl-admin/lib/collaboration/CLAUDE.md
+++ b/web/gl-admin/lib/collaboration/CLAUDE.md
@@ -51,6 +51,15 @@ A change in (1) only reaches (2) when something **mirrors** it (`pmToBlockDoc` �
    after a successful load and releases `isInitializing` in a `finally`. A failed load
    (e.g. 401) must remain retryable and must NOT permanently disable autosave.
 
+3b. **Seed the editor from the REST working copy ONLY when the live Yjs doc is empty.**
+   On a warm reload, IndexedDB + the WS server restore the prosemirror fragment and the
+   blocks maps — Yjs is the source of truth and the Collaboration plugin already shows
+   the content. `initialize()` must NOT `setContent`/`setBlockDocV1` over a non-empty
+   Yjs doc: `setContent` becomes delete-all + insert-new on the fragment (via ySyncPlugin),
+   creating a competing parallel state the 2s resync then fights — reverting the user's
+   content (the reload "heartbeat", reproducible via Ctrl+S then reload). Guard with
+   `!editor.isEmpty` / a non-empty `getBlockDocV1()`; only seed the side(s) that are empty.
+
 4. **`saveTimer` must be nulled when the debounce timer fires** (inside the
    `setTimeout` callback). The missed-timer recovery in `performSave`'s `finally` checks
    `!this.saveTimer`; a stale (fired-but-not-nulled) ref makes it skip rescheduling and

--- a/web/gl-admin/lib/collaboration/CLAUDE.md
+++ b/web/gl-admin/lib/collaboration/CLAUDE.md
@@ -4,12 +4,29 @@ This is the **most sensitive subsystem in the codebase**. It has bitten us repea
 with data-loss and feedback-loop bugs. It now has real test coverage — keep it green
 and add to it. Run `npm test` from `web/` after any change here.
 
+## ⚠️ The 2026-06 data-loss saga: resolved (read this first)
+
+The recurring "heartbeat" (content/images erased by autosaves with no typing, worse on
+every save+reload) was a **stack of five real bugs**, fixed on PR #204. The decisive
+root cause was **server-side: a dual yjs instance (ESM+CJS double-load)** in
+`websocket/` — see the top gotcha in `websocket/CLAUDE.md`. The other four were real
+and remain guarded by the hard rules below: client IndexedDB cache divergence (rule 0),
+the BlockId remote-update feedback loop (rule 7), duplicate `data-block-id`s on
+block-split, and client/server yjs version skew (rule 8). Debugging lesson: the
+browser-side symptom (server reasserting a frozen state every 2s = `resyncInterval`)
+pointed at the *server* long before the cause was found, and the yjs warning
+"Yjs was already imported" had been printed at every server boot — **read process logs
+from the very top**.
+
 ## The big mental model: TWO separate Yjs structures
 
 A post's `Y.Doc` (keyed `post-<id>`) holds **two independent shared types**:
 
-1. **`prosemirror` XmlFragment** — the editor content. The TipTap **Collaboration**
-   extension binds the editor to this. This is what the user sees/types.
+1. **The `"default"` XmlFragment** — the editor content. The TipTap **Collaboration**
+   extension binds the editor to this (`Collaboration.configure({ document })` with no
+   `field` option = fragment name `"default"`). **It is NOT named `"prosemirror"`** —
+   code inspecting `getXmlFragment("prosemirror")` reads an always-empty fragment (this
+   bug made all debug fingerprints useless during the saga's early diagnosis).
 2. **`blocks` + `blocks_order` Y.Maps** — the **Block Spec v1 mirror**, managed by
    `BlockDocManager`. This is a *derived* representation used for persistence + SSR.
 
@@ -97,7 +114,16 @@ A change in (1) only reaches (2) when something **mirrors** it (`pmToBlockDoc` �
    `@tiptap/extension-collaboration`): `if (transactions.some(tr => isChangeOrigin(tr)))
    return null`. Only the client that originates a node assigns its id; remote ids arrive
    as synced attributes and `pmToBlockDoc` backfills any missing at save time. Any future
-   doc-mutating plugin must do the same.
+   doc-mutating plugin must do the same. (BlockIdExtension also regenerates **duplicate**
+   ids — splitting a block copies attrs incl. the id onto the new node; the `blocks` map
+   is keyed by id, so duplicates silently collapse blocks on save. Keep both checks.)
+
+8. **`yjs` must be the exact same version in `web/` and `websocket/`** (currently pinned
+   `13.6.31`, no `^`), and y-websocket/y-protocols kept in lockstep. The two packages
+   have separate lockfiles, so loose ranges drift apart silently; mixed yjs versions
+   between peers can mis-integrate complex struct operations (Yjs requires all peers on
+   one version). Related but distinct: the **server-side dual ESM/CJS instance** hazard —
+   see `websocket/CLAUDE.md`, it's the top gotcha there.
 
 ## State machine flags (BlockPersistenceManager)
 
@@ -124,8 +150,17 @@ resolves, edits arrived mid-flight so DON'T clear `hasUnsavedChanges`) · `saveT
   in-flight Yjs state. See `websocket/CLAUDE.md`.
 - **Diagnostic finding (convergence harness, `reconnect.test.ts`):** at the pure-CRDT
   sync level, content is NEVER lost — not on disconnect, server restart, cleared
-  snapshot, or repeated resyncs. So editor-level bugs here are at the **editor-binding /
-  autosave layer**, not in Yjs sync. Start debugging there.
+  snapshot, or repeated resyncs. **Caveat learned the hard way:** these tests run in ONE
+  module system, so they can never reproduce the production dual-instance hazard
+  (ESM tests + CJS server builds). A green harness rules out CRDT logic, NOT the
+  server's runtime environment.
+- **Debugging a "server reasserts stale state every 2s" symptom:** that cadence is
+  `resyncInterval: 2000`; a server doc that stops integrating a client's updates
+  ("wedged" — typically right after a structural edit like an Enter-split or
+  paragraph→heading) re-erases the client on every resync. First check the websocket
+  container logs **from the very top** for "Yjs was already imported" and for swallowed
+  stack traces from y-websocket's messageListener (it `console.error`s and drops failed
+  integrations, leaving a permanent causal gap).
 
 ## How to test headlessly
 
@@ -143,5 +178,7 @@ resolves, edits arrived mid-flight so DON'T clear `hasUnsavedChanges`) · `saveT
   A real client-wins/merge (or at least a user warning) is wanted. Pinned by a test.
 - `setBlockDocV1` still does full delete+insert on the **order array** when it differs
   (fine — small, infrequent) and still rewrites *changed* blocks (expected).
-- StarterKit history vs collaboration history conflict (see `web/CLAUDE.md`).
+- Strategic refactor on the table: replace the bespoke y-websocket demo-server stack
+  with **Hocuspocus** (server-side load/store of `block_doc`, client becomes a dumb
+  editor) — tracked as a GitHub issue in the MVP milestone.
 </content>

--- a/web/gl-admin/lib/collaboration/CollaborationProvider.ts
+++ b/web/gl-admin/lib/collaboration/CollaborationProvider.ts
@@ -1,7 +1,7 @@
 import { WebsocketProvider } from "y-websocket"
 import { Doc as YDoc } from "yjs"
 import { authManager } from "../auth"
-import { collabDebug, collabDebugEnabled, contentFingerprint } from "./debug"
+import { collabDebug, collabDebugEnabled, contentFingerprint, fragmentStructure } from "./debug"
 
 const activeProviders = new Map<number, CollaborationProvider>()
 const refCounts = new Map<number, number>()
@@ -102,7 +102,7 @@ export class CollaborationProvider {
         if (!collabDebugEnabled()) return
         const originName =
           origin == null ? "local" : (origin as any)?.constructor?.name ?? String(origin)
-        collabDebug("doc update", "origin", originName, fp())
+        collabDebug("doc update", "origin", originName, fp(), "|", fragmentStructure(frag))
       })
     }
   }

--- a/web/gl-admin/lib/collaboration/CollaborationProvider.ts
+++ b/web/gl-admin/lib/collaboration/CollaborationProvider.ts
@@ -1,6 +1,5 @@
 import { WebsocketProvider } from "y-websocket"
 import { Doc as YDoc } from "yjs"
-import { IndexeddbPersistence } from "y-indexeddb"
 import { authManager } from "../auth"
 import { collabDebug, collabDebugEnabled, contentFingerprint } from "./debug"
 
@@ -12,7 +11,6 @@ const DESTROY_DELAY_MS = 750
 export class CollaborationProvider {
   public doc: YDoc
   public provider: WebsocketProvider
-  public persistence: IndexeddbPersistence
   private postId: number
 
   static getInstance(postId: number): CollaborationProvider {
@@ -43,7 +41,13 @@ export class CollaborationProvider {
 
     this.doc = new YDoc()
 
-    this.persistence = new IndexeddbPersistence(`post-${postId}`, this.doc)
+    // NOTE: no client-side IndexedDB persistence. The WS server (LevelDB) is the SINGLE
+    // source of truth for the collaborative Yjs state. A client-side cache that survives
+    // reloads inevitably diverges from the server's rebuilt doc (different struct
+    // histories for the same content), and that divergence compounds on every reload —
+    // the root of the recurring "heartbeat"/content-erasure. Content also lives durably
+    // in Postgres (posts.block_doc) via the REST autosave, so dropping the local cache
+    // loses no data; the editor simply loads from the server on open.
 
     const user = authManager.getState().user
     const userInfo = {
@@ -73,21 +77,29 @@ export class CollaborationProvider {
 
     this.provider.on("status", () => {})
 
-    // Debug-gated instrumentation (localStorage GL_DEBUG_COLLAB=1) for diagnosing
-    // the WS-restart instability. Logs reconnect cadence + the prosemirror fragment
-    // fingerprint over time so we can see exactly when/why content reverts.
-    if (collabDebugEnabled()) {
+    // Debug instrumentation (localStorage GL_DEBUG_COLLAB=1) for diagnosing content
+    // reverts. The listeners are ALWAYS attached and re-check the flag at call time, so it
+    // can be toggled at runtime (set the flag, reload) without having to be set before this
+    // run-once constructor executed. The previous "if (enabled) attach" gating meant a flag
+    // set after page load produced no logs at all — which silently blinded earlier
+    // diagnosis. fp() (which serialises the fragment) only runs when the flag is on, so the
+    // disabled path stays cheap.
+    {
       const frag = this.doc.getXmlFragment("default")
       const fp = () => contentFingerprint(frag.toJSON())
-      collabDebug("provider created", `post-${postId}`, fp())
-      this.provider.on("status", (e: any) => collabDebug("ws status", e?.status, fp()))
-      this.provider.on("sync", (isSynced: boolean) =>
-        collabDebug("provider sync", isSynced, "wsconnected", this.provider.wsconnected, fp())
-      )
-      this.provider.on("connection-error", (e: any) =>
-        collabDebug("connection-error", e?.message || String(e))
-      )
+      if (collabDebugEnabled()) collabDebug("provider created", `post-${postId}`, fp())
+      this.provider.on("status", (e: any) => {
+        if (collabDebugEnabled()) collabDebug("ws status", e?.status, fp())
+      })
+      this.provider.on("sync", (isSynced: boolean) => {
+        if (collabDebugEnabled())
+          collabDebug("provider sync", isSynced, "wsconnected", this.provider.wsconnected, fp())
+      })
+      this.provider.on("connection-error", (e: any) => {
+        if (collabDebugEnabled()) collabDebug("connection-error", e?.message || String(e))
+      })
       this.doc.on("update", (_update: Uint8Array, origin: unknown) => {
+        if (!collabDebugEnabled()) return
         const originName =
           origin == null ? "local" : (origin as any)?.constructor?.name ?? String(origin)
         collabDebug("doc update", "origin", originName, fp())
@@ -96,14 +108,14 @@ export class CollaborationProvider {
   }
 
   /**
-   * Resolves once the IndexedDB persistence has finished its initial load into the
-   * Y.Doc. Callers MUST await this before deciding whether to seed the editor from a
-   * non-Yjs source (the REST working copy): otherwise the doc can look empty on the WS
-   * "synced" tick while IndexedDB is still loading, and a setContent seed would mint
-   * fresh structs that then collide with IndexedDB's — diverging the document.
+   * Kept for API compatibility with the seed path in Editor.tsx. There is no longer a
+   * client-side IndexedDB layer to wait for — the WS `synced` event (which already gates
+   * the seed in onSynced) is the single signal that the server's authoritative state has
+   * loaded into the Y.Doc. So this resolves immediately; the seed decision is made purely
+   * on `editor.isEmpty` after WS sync.
    */
   get whenSynced(): Promise<unknown> {
-    return this.persistence.whenSynced
+    return Promise.resolve()
   }
 
   private generateUserColor(userId: number): string {
@@ -116,7 +128,6 @@ export class CollaborationProvider {
 
     this.provider?.disconnect()
     this.provider?.destroy()
-    this.persistence?.destroy()
     this.doc?.destroy()
   }
 
@@ -129,7 +140,6 @@ export class CollaborationProvider {
         if (!inst) return
         inst.provider?.disconnect()
         inst.provider?.destroy()
-        inst.persistence?.destroy()
         inst.doc?.destroy()
         activeProviders.delete(postId)
         releaseTimers.delete(postId)

--- a/web/gl-admin/lib/collaboration/CollaborationProvider.ts
+++ b/web/gl-admin/lib/collaboration/CollaborationProvider.ts
@@ -77,7 +77,7 @@ export class CollaborationProvider {
     // the WS-restart instability. Logs reconnect cadence + the prosemirror fragment
     // fingerprint over time so we can see exactly when/why content reverts.
     if (collabDebugEnabled()) {
-      const frag = this.doc.getXmlFragment("prosemirror")
+      const frag = this.doc.getXmlFragment("default")
       const fp = () => contentFingerprint(frag.toJSON())
       collabDebug("provider created", `post-${postId}`, fp())
       this.provider.on("status", (e: any) => collabDebug("ws status", e?.status, fp()))
@@ -93,6 +93,17 @@ export class CollaborationProvider {
         collabDebug("doc update", "origin", originName, fp())
       })
     }
+  }
+
+  /**
+   * Resolves once the IndexedDB persistence has finished its initial load into the
+   * Y.Doc. Callers MUST await this before deciding whether to seed the editor from a
+   * non-Yjs source (the REST working copy): otherwise the doc can look empty on the WS
+   * "synced" tick while IndexedDB is still loading, and a setContent seed would mint
+   * fresh structs that then collide with IndexedDB's — diverging the document.
+   */
+  get whenSynced(): Promise<unknown> {
+    return this.persistence.whenSynced
   }
 
   private generateUserColor(userId: number): string {

--- a/web/gl-admin/lib/collaboration/debug.ts
+++ b/web/gl-admin/lib/collaboration/debug.ts
@@ -9,6 +9,10 @@
  * Used to capture the disconnect → reconnect → resync sequence when diagnosing
  * the WS-restart instability. Every line is timestamped so client logs can be
  * aligned against the WS server's COLLAB_DEBUG logs on the same timeline.
+ *
+ * NOTE: uses `console.log`, NOT `console.debug` — Chrome's console hides debug-level
+ * messages unless "Verbose" is enabled in the level filter, which made these logs appear
+ * to be missing entirely even with the flag set. Keep it as `console.log`.
  */
 export function collabDebugEnabled(): boolean {
   try {
@@ -21,7 +25,7 @@ export function collabDebugEnabled(): boolean {
 export function collabDebug(...args: unknown[]): void {
   if (collabDebugEnabled()) {
     // eslint-disable-next-line no-console
-    console.debug(`[collab t=${Date.now()}]`, ...args)
+    console.log(`[collab t=${Date.now()}]`, ...args)
   }
 }
 

--- a/web/gl-admin/lib/collaboration/debug.ts
+++ b/web/gl-admin/lib/collaboration/debug.ts
@@ -35,6 +35,37 @@ export function collabDebug(...args: unknown[]): void {
  * input. JSON.stringify can throw (circular refs, BigInt), so it's wrapped — debug
  * instrumentation must never be able to crash the app when GL_DEBUG_COLLAB is on.
  */
+/**
+ * Compact, per-top-level-node summary of a Y.XmlFragment so we can see WHICH block
+ * appears/disappears/changes id between a local edit and a server push (the fingerprint
+ * only gives a total length+hash, which can't localise a divergence). Renders each child
+ * as `nodeName#blockIdPrefix(serialisedLen)`, e.g. `paragraph#a1b2c3(45) image#—(0)`.
+ * Defensive: instrumentation must never throw.
+ */
+export function fragmentStructure(frag: unknown): string {
+  try {
+    const f = frag as { toArray?: () => unknown[] }
+    const children = typeof f?.toArray === "function" ? f.toArray() : []
+    if (children.length === 0) return "(empty)"
+    return children
+      .map((c) => {
+        const el = c as {
+          nodeName?: string
+          getAttribute?: (k: string) => unknown
+          toString?: () => string
+        }
+        const name = el?.nodeName ?? "text"
+        const id = typeof el?.getAttribute === "function" ? el.getAttribute("data-block-id") : null
+        const idShort = id ? String(id).slice(0, 6) : "—"
+        const len = typeof el?.toString === "function" ? el.toString().length : 0
+        return `${name}#${idShort}(${len})`
+      })
+      .join(" ")
+  } catch (e) {
+    return `<structerr ${String(e)}>`
+  }
+}
+
 export function contentFingerprint(value: unknown): string {
   let text: string
   if (typeof value === "string") {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -60,9 +60,9 @@
         "tippy.js": "^6.3.7",
         "y-indexeddb": "^9.0.12",
         "y-prosemirror": "^1.3.7",
-        "y-protocols": "^1.0.6",
-        "y-websocket": "^2.0.4",
-        "yjs": "^13.6.18"
+        "y-protocols": "^1.0.7",
+        "y-websocket": "^2.1.0",
+        "yjs": "13.6.31"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -13162,9 +13162,9 @@
       }
     },
     "node_modules/y-protocols": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.6.tgz",
-      "integrity": "sha512-vHRF2L6iT3rwj1jub/K5tYcTT/mEYDUppgNPXwp8fmLpui9f7Yeq3OEtTLVF012j39QnV+KEQpNqoN7CWU7Y9Q==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
+      "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
       "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.85"
@@ -13182,9 +13182,9 @@
       }
     },
     "node_modules/y-websocket": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/y-websocket/-/y-websocket-2.0.4.tgz",
-      "integrity": "sha512-UbrkOU4GPNFFTDlJYAxAmzZhia8EPxHkngZ6qjrxgIYCN3gI2l+zzLzA9p4LQJ0IswzpioeIgmzekWe7HoBBjg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/y-websocket/-/y-websocket-2.1.0.tgz",
+      "integrity": "sha512-WHYDRqomaGkkaujtowCDwL8KYk+t1zQCGIgKyvxvchhjTQlMgWXRHJK+FDEcWmHA7I7o/4fy0eniOrtmz0e4mA==",
       "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.52",
@@ -13227,12 +13227,12 @@
       }
     },
     "node_modules/yjs": {
-      "version": "13.6.18",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.18.tgz",
-      "integrity": "sha512-GBTjO4QCmv2HFKFkYIJl7U77hIB1o22vSCSQD1Ge8ZxWbIbn8AltI4gyXbtL+g5/GJep67HCMq3Y5AmNwDSyEg==",
+      "version": "13.6.31",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.31.tgz",
+      "integrity": "sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==",
       "license": "MIT",
       "dependencies": {
-        "lib0": "^0.2.86"
+        "lib0": "^0.2.99"
       },
       "engines": {
         "node": ">=16.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -64,9 +64,9 @@
     "tippy.js": "^6.3.7",
     "y-indexeddb": "^9.0.12",
     "y-prosemirror": "^1.3.7",
-    "y-protocols": "^1.0.6",
-    "y-websocket": "^2.0.4",
-    "yjs": "^13.6.18"
+    "y-protocols": "^1.0.7",
+    "y-websocket": "^2.1.0",
+    "yjs": "13.6.31"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/websocket/CLAUDE.md
+++ b/websocket/CLAUDE.md
@@ -36,9 +36,20 @@ publish (`triggerCollabSquash`). `DATA_PATH` and `SQUASH_SECRET` come from
 
 ## Gotchas (learned the hard way)
 
-- **`yjs` is a direct dependency** of this package (server.js does `import * as Y`).
-  Keep it direct + a single deduped copy — two yjs instances cause
-  `integrateStructs`/`splice` corruption.
+- **ONE yjs INSTANCE, not just one copy (THE root cause of the editor data-loss saga).**
+  A single deduped `node_modules/yjs` is NOT enough: yjs and y-leveldb ship dual
+  ESM+CJS builds, and `y-websocket/bin/utils` is CJS (`require("yjs")` → `yjs.cjs`)
+  while this package is ESM (`import "yjs"` → `yjs.mjs`) — the same package evaluated
+  TWICE with separate class registries. Cross-instance calls (`Y.applyUpdate` from the
+  ESM build onto the CJS `WSSharedDoc` in bindState) fail yjs's internal constructor
+  checks and silently corrupt the doc: it "wedges" (stops integrating a client's updates
+  — structural edits like Enter-splits or paragraph→heading trigger it) and the client's
+  2s resync then erases the user's typed content. The tell: yjs prints
+  **"Yjs was already imported. This breaks constructor checks…"** at startup (yjs#438).
+  Therefore `server.js`/`persistence.js`/tests load yjs + y-leveldb + bin/utils via
+  `createRequire` (all CJS, one instance), and `server.js` has a startup probe that
+  `process.exit(1)`s if a doc from bin/utils isn't `instanceof` our `Y.Doc`. Never
+  revert these to bare ESM imports, and treat that startup warning as a release blocker.
 - **`ldb.destroy()` does NOT delete data** — it's poorly named; it calls
   `db.close()`. The destructive method is `clearAll()`. Calling `destroy()` on shutdown
   is correct (a reviewer flagged it as wiping data — it doesn't).

--- a/websocket/package-lock.json
+++ b/websocket/package-lock.json
@@ -12,8 +12,8 @@
         "paseto": "^3.1.2",
         "ws": "^8.16.0",
         "y-leveldb": "^0.2.0",
-        "y-websocket": "^2.0.4",
-        "yjs": "^13.6.31"
+        "y-websocket": "^2.1.0",
+        "yjs": "13.6.31"
       },
       "devDependencies": {
         "nodemon": "^3.1.0"

--- a/websocket/package.json
+++ b/websocket/package.json
@@ -10,9 +10,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "y-websocket": "^2.0.4",
+    "y-websocket": "^2.1.0",
     "y-leveldb": "^0.2.0",
-    "yjs": "^13.6.31",
+    "yjs": "13.6.31",
     "ws": "^8.16.0",
     "paseto": "^3.1.2",
     "dotenv": "^16.4.5"

--- a/websocket/persistence.js
+++ b/websocket/persistence.js
@@ -1,4 +1,13 @@
-import * as Y from "yjs";
+import { createRequire } from "node:module";
+
+// Must be the SAME yjs instance as y-websocket/bin/utils and y-leveldb (their CJS
+// builds). An ESM `import * as Y from "yjs"` would load the second (ESM) build, and
+// cross-instance calls — encodeStateAsUpdate on a doc y-leveldb built, applyUpdate onto
+// the live WSSharedDoc — fail yjs's internal constructor checks and corrupt documents.
+// See the root-cause comment in server.js.
+const require = createRequire(import.meta.url);
+/** @type {typeof import("yjs")} */
+const Y = require("yjs");
 
 /**
  * Returns true if a Y.Doc has un-integrated ("pending") structs — i.e. it was

--- a/websocket/persistence.test.js
+++ b/websocket/persistence.test.js
@@ -1,7 +1,14 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import * as Y from "yjs";
+import { createRequire } from "node:module";
 import { evaluatePersistedState, hasPendingStructs } from "./persistence.js";
+
+// Use the CJS yjs build — the same single instance persistence.js/server.js use.
+// An ESM import here would load the second (ESM) build, and docs created by this test
+// would cross instances inside evaluatePersistedState — the exact production bug the
+// createRequire pattern guards against (see server.js).
+const require = createRequire(import.meta.url);
+const Y = require("yjs");
 
 /** Minimal y-leveldb stand-in: getYDoc returns a provided doc; clearDocument noop. */
 function fakeLdb(getYDoc) {

--- a/websocket/server.js
+++ b/websocket/server.js
@@ -1,6 +1,6 @@
 import "dotenv/config";
 import { WebSocketServer } from "ws";
-import { setupWSConnection, setPersistence } from "y-websocket/bin/utils";
+import { setupWSConnection, setPersistence, docs } from "y-websocket/bin/utils";
 import { LeveldbPersistence } from "y-leveldb";
 import * as Y from "yjs";
 import { evaluatePersistedState } from "./persistence.js";
@@ -28,7 +28,14 @@ const COLLAB_DEBUG = (process.env.COLLAB_DEBUG || "").trim() === "1";
 const collabDebug = (...args) => {
   if (COLLAB_DEBUG) console.debug(`[collab t=${Date.now()}]`, ...args);
 };
-const docLen = (ydoc) => ydoc.getXmlFragment("prosemirror").length;
+// The editor binds the @tiptap/extension-collaboration document to the "default"
+// XmlFragment (NOT "prosemirror"). Measuring "prosemirror" always returned 0, making
+// every server-side length log meaningless during past diagnosis. Measure "default".
+const docLen = (ydoc) => ydoc.getXmlFragment("default").length;
+
+// Derive the Yjs document name (e.g. "post-2892") from the upgrade request URL, the
+// same way y-websocket's setupWSConnection does, so we can correlate connection counts.
+const docNameFromReq = (req) => (req.url || "/").slice(1).split("?")[0].split("#")[0];
 
 console.log("🔍 Environment debug:");
 console.log("   - process.env.HOST:", process.env.HOST);
@@ -155,9 +162,26 @@ setPersistence({
     Y.applyUpdate(ydoc, result.update, PERSISTENCE_ORIGIN);
     collabDebug("bindState applied persisted state", docName, "liveDocLen", docLen(ydoc));
   },
-  writeState: async (_docName, _ydoc) => {
-    // No-op: updates are written incrementally in the bindState update listener.
-    // writeState fires when the last client disconnects; nothing extra needed here.
+  writeState: async (docName, _ydoc) => {
+    // Compact the append-only update log into a single snapshot when the last client
+    // disconnects. Updates are written incrementally by the bindState listener, but that
+    // log was ONLY ever squashed on publish — so across a session it grew unbounded, and
+    // because y-websocket destroys + rebuilds the in-memory doc from the FULL log every
+    // time the client count hits zero (which a browser reload does), every reconnect
+    // replayed an ever-larger history. When that history contains divergent struct sets
+    // for the same content (e.g. legacy pre-fix re-seeds), the rebuilt doc oscillates and
+    // the editor never converges — the "gets worse on every reload" erasure. flushDocument
+    // merges all stored updates for this doc into one, keeping the replayed state compact
+    // and stable. It does NOT drop content (CRDT merge), only collapses the log.
+    try {
+      await ldb.flushDocument(docName);
+      collabDebug("writeState flushed", docName);
+    } catch (err) {
+      console.error(
+        `⚠️  Failed to flush ${docName} on last disconnect:`,
+        err?.message || err
+      );
+    }
   },
 });
 
@@ -201,9 +225,12 @@ const server = http.createServer(async (req, res) => {
 
 const wss = new WebSocketServer({ noServer: true });
 wss.on("connection", (ws, req) => {
+  const docName = docNameFromReq(req);
   console.log(
     "✅ WebSocket connection established for user:",
     req.auth?.username || "unknown",
+    "doc:",
+    docName,
   );
 
   // Keep connection alive to prevent idle disconnects behind proxies
@@ -219,9 +246,21 @@ wss.on("connection", (ws, req) => {
 
   ws.on("close", () => {
     clearInterval(keepAliveInterval);
+    // Log AFTER y-websocket has removed this conn so the count reflects survivors.
+    setTimeout(() => {
+      const remaining = docs.get(docName)?.conns.size ?? 0;
+      console.log(`🔌 WS close — doc: ${docName} | live connections now: ${remaining}`);
+    }, 0);
   });
 
   setupWSConnection(ws, req);
+
+  // Always-on (not COLLAB_DEBUG-gated) so we can spot a runaway client count: a single
+  // editor tab must show exactly 1 live connection per post. More than 1 with one tab
+  // open means a zombie/duplicate binder is fighting over the doc — the kind of thing
+  // that produces an unkillable server-vs-editor tug-of-war.
+  const liveConns = docs.get(docName)?.conns.size ?? 0;
+  console.log(`🔗 WS open — doc: ${docName} | live connections now: ${liveConns}`);
 });
 
 server.on("upgrade", async (req, socket, head) => {

--- a/websocket/server.js
+++ b/websocket/server.js
@@ -1,14 +1,49 @@
 import "dotenv/config";
 import { WebSocketServer } from "ws";
-import { setupWSConnection, setPersistence, docs } from "y-websocket/bin/utils";
-import { LeveldbPersistence } from "y-leveldb";
-import * as Y from "yjs";
+import { createRequire } from "node:module";
 import { evaluatePersistedState } from "./persistence.js";
 import { URL } from "url";
 import { V4 } from "paseto";
 import { createPublicKey } from "crypto";
 import http from "http";
 import fs from "fs";
+
+// CRITICAL — single-yjs-instance rule (the root cause of the editor data-loss bugs):
+// yjs and y-leveldb ship BOTH ESM and CJS builds. y-websocket's server utils
+// (bin/utils.cjs) are CJS, so their require("yjs") loads dist/yjs.cjs. An ESM
+// `import * as Y from "yjs"` here loads dist/yjs.mjs — the SAME package evaluated a
+// SECOND time, with a separate class registry. Yjs itself warns at startup:
+//   "Yjs was already imported. This breaks constructor checks and will lead to
+//    issues!" (https://github.com/yjs/yjs/issues/438)
+// The damage: bindState's Y.applyUpdate (ESM build) onto the WSSharedDoc (CJS build)
+// fails yjs's internal constructor checks and silently mis-integrates, structurally
+// corrupting the live doc. Symptom: the doc "wedges" — it stops integrating a client's
+// updates (structural edits like Enter-splits / paragraph→heading trigger it), and the
+// 2s resync then resets that client's editor to the wedged state, erasing typed content.
+// So: load yjs / y-leveldb / bin/utils through createRequire so this whole process
+// shares the single CJS instance. The startup probe below hard-fails on regression.
+const require = createRequire(import.meta.url);
+const { setupWSConnection, setPersistence, docs, getYDoc } = require("y-websocket/bin/utils");
+const { LeveldbPersistence } = require("y-leveldb");
+const Y = require("yjs");
+
+// Fail fast if two yjs builds are ever loaded again (e.g. someone reverts the requires
+// above to ESM imports). A doc created by y-websocket's utils must be an instance of OUR
+// Y.Doc — if not, every cross-instance call corrupts documents, which is far worse than
+// a server that refuses to boot. Runs before setPersistence so bindState isn't invoked.
+{
+  const probe = getYDoc("__yjs-instance-probe__");
+  const sameInstance = probe instanceof Y.Doc;
+  probe.destroy();
+  docs.delete("__yjs-instance-probe__");
+  if (!sameInstance) {
+    console.error(
+      "❌ FATAL: two yjs instances are loaded (ESM/CJS dual import). " +
+        "All yjs-family packages must resolve to the same build — see the comment above this check.",
+    );
+    process.exit(1);
+  }
+}
 
 const HOST = process.env.HOST || "localhost";
 const PORT = Number(process.env.PORT) || 1234;


### PR DESCRIPTION
Started as the two remaining editor cleanup issues (#197, #198) — and became the branch that **resolved the collaborative-editor data-loss saga** (the "heartbeat": content/images erased by autosaves with no typing, getting worse with every save+reload). Verified live: typing, Enter-splits, paragraph→heading conversions, images, Ctrl+S, repeated reloads, publish, and multi-client collab all hold.

## The root cause: a dual yjs instance on the WS server (ESM+CJS double-load)

`yjs` and `y-leveldb` ship dual ESM+CJS builds. `y-websocket/bin/utils` is CJS (`require("yjs")` → `yjs.cjs`), while our ESM `server.js` did `import * as Y from "yjs"` (→ `yjs.mjs`): the same package evaluated **twice**, with two separate class registries. `npm ls` shows a single deduped copy, so every dependency audit passed. Yjs itself flagged it on **every boot** — `"Yjs was already imported. This breaks constructor checks and will lead to issues!"` (yjs#438) — above the startup banner, where nobody looked.

The damage: `bindState` ran `Y.applyUpdate` (ESM build) onto the live `WSSharedDoc` (CJS build) on every reconnect that had persisted state. Yjs's internal constructor checks fail across builds, integration silently takes wrong branches, and the doc **wedges** — it stops integrating the client's updates (structural edits like Enter-splits or paragraph→heading trigger it), and the client's 2s resync then resets the editor to the wedged state, erasing typed content.

**Fix:** `server.js`/`persistence.js`/tests load yjs, y-leveldb and bin/utils via `createRequire` (one shared CJS instance), plus a startup probe that `exit(1)`s if a doc from bin/utils is ever not `instanceof` our `Y.Doc`. Verified: the dual-import warning is gone.

## The other four bugs fixed on this branch (each real, each guarded now)

1. **Client IndexedDB cache removed** — a client-side Yjs store that survives reloads builds a different struct history than the server's rebuilt doc; the two never converge and it compounds per reload. The WS server (LevelDB) is now the single live Yjs store; Postgres `block_doc` stays canonical. (collab CLAUDE.md rule 0)
2. **BlockIdExtension remote-update feedback loop** — `appendTransaction` minted fresh `crypto.randomUUID()` block-ids in response to transactions `ySyncPlugin` dispatched for *remote* updates → sync→mint→sync forever. Now guarded with TipTap's `isChangeOrigin()`. (rule 7)
3. **Duplicate `data-block-id`s** — splitting a block copies attrs (incl. the id) onto the new node; the `blocks` map is keyed by id, so duplicates silently collapsed blocks on save. The extension now regenerates duplicates, not just missing ids.
4. **yjs version skew** — web resolved `yjs@13.6.18`/`y-websocket@2.0.4` while the server had `13.6.31`/`2.1.0` (separate lockfiles, loose ranges). Yjs requires all peers on one version. Both now pin `yjs@13.6.31` exact. (rule 8)

Plus hardening/diagnostics that made the diagnosis possible: LevelDB log compaction on last-disconnect (`writeState` was a no-op; the unbounded update log was replayed in full on every reconnect), always-on per-doc connection-count logging, per-block fragment-structure debug logging, debug listeners that honor `GL_DEBUG_COLLAB` toggled at runtime, `console.log` instead of the Chrome-hidden `console.debug`, and the fragment-name fix (the editor binds `"default"`, not `"prosemirror"` — all earlier fingerprints read an always-empty fragment).

## #197 — disable StarterKit undo/redo under Collaboration

`StarterKit.configure({ undoRedo: collabProvider ? false : undefined })` — Collaboration ships its own Yjs-aware undo with `Mod-z`/`Mod-y`/`Shift-Mod-z` keymaps; non-collab editors keep StarterKit's.

## #198 — create the editor once (theme-gate wrapper)

The editor was created twice in production (3× dev) — base extensions first, again when `isThemeLoaded` flipped. A thin `forwardRef` gate now mounts `EditorInner` once with the full extension set (separate wrapper required by the Rules of Hooks).

## Docs

All discoveries are locked into the scoped agent-context files: `websocket/CLAUDE.md` (top gotcha: the dual-instance hazard + guards), `web/gl-admin/lib/collaboration/CLAUDE.md` (saga summary + hard rules 0–8), `web/CLAUDE.md`, root `CLAUDE.md`.

## Test plan
- [x] `cd web && npm test` → 73 pass
- [x] `cd websocket && npm test` → 4 pass
- [x] Server boots with **no** "Yjs was already imported" warning; instance probe passes
- [x] Live (fresh `ws_data` volume): type, split blocks, convert paragraph→heading, add image, Ctrl+S, reload repeatedly, publish → content persists, no idle PUTs, no heartbeat
- [x] Multi-client collab verified working
- [ ] Note for deploy: wipe the `ws_data` volume once (existing LevelDB data was written through corrupted integrations)

Closes #197, #198

