### PR TITLE
security: sanitize HTML output from the Block Spec v1 renderer (#188)

### DIFF
--- a/api/post_blocks_handlers.go
+++ b/api/post_blocks_handlers.go
@@ -231,6 +231,12 @@ func (server *Server) updatePostBlocks(c *gin.Context) {
 	// Deduplicate blocks_order to prevent duplicate rendering
 	req.Doc.deduplicateBlocksOrder()
 
+	// Sanitize the block tree before it is persisted (stored-XSS defence, #188).
+	// Neutralises dangerous link/image URL schemes, on* handler attrs, disallowed
+	// node types, and unsafe highlight colors. Best-effort, never rejects the save.
+	// publishPost reads this already-sanitized working copy, so it's covered too.
+	req.Doc.sanitize()
+
 	// Validate Block Spec v1
 	if req.Doc.DocVersion != 1 {
 		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("unsupported doc_version: %d", req.Doc.DocVersion)})

--- a/api/post_blocks_sanitize.go
+++ b/api/post_blocks_sanitize.go
@@ -1,0 +1,174 @@
+package api
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// Server-side sanitization of Block Spec v1 documents (issue #188).
+//
+// Block content is structured ProseMirror JSON, not an HTML string, so an HTML
+// sanitizer (bluemonday) is the wrong tool. We walk the block tree in place and
+// neutralise the stored-XSS vectors the public Astro renderer would otherwise
+// emit verbatim (link hrefs, image srcs, highlight colors), plus defence-in-depth
+// stripping of on* handler attributes and dangerous node types.
+//
+// Sanitization is best-effort and never rejects the save — the malicious payload
+// is simply stripped so it never reaches the database.
+
+// Node types that must never appear in stored block content.
+var disallowedNodeTypes = map[string]bool{
+	"script": true, "iframe": true, "object": true, "embed": true, "style": true,
+}
+
+// URL schemes permitted in link hrefs. Anything else (javascript:, data:,
+// vbscript:, file:, …) is rejected.
+var safeHrefSchemes = map[string]bool{
+	"http": true, "https": true, "mailto": true, "tel": true,
+}
+
+// URL schemes permitted in image srcs. Images come from /uploads (relative) or
+// http(s); base64/data: is disabled in the editor and rejected here.
+var safeImageSchemes = map[string]bool{
+	"http": true, "https": true,
+}
+
+// Conservative allowlist for a CSS color value: hex, rgb/rgba, hsl/hsla, or a
+// plain named color. Rejects anything containing url(), semicolons, etc.
+var safeColorRe = regexp.MustCompile(`^(#[0-9a-fA-F]{3,8}|[a-zA-Z]+|(?:rgb|rgba|hsl|hsla)\([0-9.,%\s/]+\))$`)
+
+// sanitize walks the block document in place, neutralising stored-XSS vectors.
+func (doc *BlockDocV1) sanitize() {
+	for id, raw := range doc.Blocks {
+		blockMap, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		sanitizeBlock(blockMap)
+		doc.Blocks[id] = blockMap
+	}
+}
+
+func sanitizeBlock(block map[string]interface{}) {
+	attrs, ok := block["attrs"].(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	// Defence in depth: no on* handlers at the block-attrs level.
+	stripOnAttrs(attrs)
+
+	// Image src: blank anything that isn't a safe scheme / relative URL.
+	if src, ok := attrs["src"].(string); ok && !isSafeURL(src, safeImageSchemes) {
+		attrs["src"] = ""
+	}
+
+	// ProseMirror node tree (paragraph/heading/blockquote/list_item carry it).
+	if pm, ok := attrs["pm"].(map[string]interface{}); ok {
+		sanitizePMNode(pm)
+	}
+}
+
+// sanitizePMNode recursively sanitises a ProseMirror node map in place.
+func sanitizePMNode(node map[string]interface{}) {
+	if nattrs, ok := node["attrs"].(map[string]interface{}); ok {
+		stripOnAttrs(nattrs)
+	}
+
+	if marks, ok := node["marks"].([]interface{}); ok {
+		node["marks"] = sanitizeMarks(marks)
+	}
+
+	// Child content: drop disallowed node types, recurse into the rest.
+	if content, ok := node["content"].([]interface{}); ok {
+		kept := make([]interface{}, 0, len(content))
+		for _, ch := range content {
+			childMap, ok := ch.(map[string]interface{})
+			if !ok {
+				kept = append(kept, ch)
+				continue
+			}
+			if t, _ := childMap["type"].(string); disallowedNodeTypes[t] {
+				continue // drop dangerous node entirely
+			}
+			sanitizePMNode(childMap)
+			kept = append(kept, childMap)
+		}
+		node["content"] = kept
+	}
+}
+
+// sanitizeMarks strips on* attrs, removes link marks with unsafe hrefs (keeping
+// the text), and drops unsafe highlight colors.
+func sanitizeMarks(marks []interface{}) []interface{} {
+	kept := make([]interface{}, 0, len(marks))
+	for _, m := range marks {
+		markMap, ok := m.(map[string]interface{})
+		if !ok {
+			kept = append(kept, m)
+			continue
+		}
+
+		mType, _ := markMap["type"].(string)
+		mAttrs, _ := markMap["attrs"].(map[string]interface{})
+		if mAttrs != nil {
+			stripOnAttrs(mAttrs)
+		}
+
+		switch mType {
+		case "link":
+			if mAttrs != nil {
+				if href, ok := mAttrs["href"].(string); ok && !isSafeURL(href, safeHrefSchemes) {
+					continue // drop the whole link mark; the text content remains
+				}
+			}
+		case "highlight":
+			if mAttrs != nil {
+				if color, ok := mAttrs["color"].(string); ok && !isSafeColor(color) {
+					delete(mAttrs, "color")
+				}
+			}
+		}
+
+		kept = append(kept, markMap)
+	}
+	return kept
+}
+
+func stripOnAttrs(attrs map[string]interface{}) {
+	for k := range attrs {
+		if strings.HasPrefix(strings.ToLower(k), "on") {
+			delete(attrs, k)
+		}
+	}
+}
+
+// isSafeURL returns true for an empty string, a relative URL (no scheme), or a
+// URL whose scheme is in `allowed`. Control characters (used to smuggle
+// "java\tscript:") cause rejection.
+func isSafeURL(raw string, allowed map[string]bool) bool {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return true
+	}
+	if strings.ContainsAny(s, "\x00\n\r\t") {
+		return false
+	}
+	u, err := url.Parse(s)
+	if err != nil {
+		return false
+	}
+	if u.Scheme == "" {
+		return true // relative URL (/uploads/x.png, #anchor, ?q=1, …)
+	}
+	return allowed[strings.ToLower(u.Scheme)]
+}
+
+func isSafeColor(color string) bool {
+	c := strings.TrimSpace(color)
+	if c == "" {
+		return true
+	}
+	return safeColorRe.MatchString(c)
+}

--- a/api/post_blocks_sanitize_test.go
+++ b/api/post_blocks_sanitize_test.go
@@ -1,0 +1,212 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// paragraphWithText builds a one-block doc whose paragraph carries a single text
+// node with the given marks + node attrs, mirroring how pmToBlockDoc stores content.
+func paragraphWithText(text string, marks []interface{}, nodeAttrs map[string]interface{}) *BlockDocV1 {
+	textNode := map[string]interface{}{"type": "text", "text": text}
+	if marks != nil {
+		textNode["marks"] = marks
+	}
+	pm := map[string]interface{}{
+		"type":    "paragraph",
+		"content": []interface{}{textNode},
+	}
+	if nodeAttrs != nil {
+		pm["attrs"] = nodeAttrs
+	}
+	return &BlockDocV1{
+		DocVersion:  1,
+		BlocksOrder: []string{"b1"},
+		Blocks: map[string]interface{}{
+			"b1": map[string]interface{}{
+				"id": "b1", "type": "paragraph", "version": 1,
+				"attrs": map[string]interface{}{"pm": pm},
+			},
+		},
+	}
+}
+
+func firstTextNode(t *testing.T, doc *BlockDocV1) map[string]interface{} {
+	t.Helper()
+	b := doc.Blocks["b1"].(map[string]interface{})
+	pm := b["attrs"].(map[string]interface{})["pm"].(map[string]interface{})
+	content := pm["content"].([]interface{})
+	require.NotEmpty(t, content)
+	return content[0].(map[string]interface{})
+}
+
+func linkMark(href string) []interface{} {
+	return []interface{}{
+		map[string]interface{}{"type": "link", "attrs": map[string]interface{}{"href": href}},
+	}
+}
+
+func TestSanitize_LinkHref(t *testing.T) {
+	t.Run("removes a javascript: link mark but keeps the text", func(t *testing.T) {
+		doc := paragraphWithText("click me", linkMark("javascript:alert(1)"), nil)
+		doc.sanitize()
+		node := firstTextNode(t, doc)
+		require.Equal(t, "click me", node["text"])
+		marks, _ := node["marks"].([]interface{})
+		require.Empty(t, marks, "javascript: link mark must be stripped")
+	})
+
+	t.Run("rejects data: and vbscript: hrefs", func(t *testing.T) {
+		for _, href := range []string{"data:text/html,<script>alert(1)</script>", "vbscript:msgbox(1)", "java\tscript:alert(1)"} {
+			doc := paragraphWithText("x", linkMark(href), nil)
+			doc.sanitize()
+			marks, _ := firstTextNode(t, doc)["marks"].([]interface{})
+			require.Empty(t, marks, "unsafe href %q must be stripped", href)
+		}
+	})
+
+	t.Run("preserves safe hrefs (https, mailto, relative)", func(t *testing.T) {
+		for _, href := range []string{"https://example.com", "http://example.com/x?y=1", "mailto:a@b.com", "/internal/page", "#anchor"} {
+			doc := paragraphWithText("x", linkMark(href), nil)
+			doc.sanitize()
+			marks, _ := firstTextNode(t, doc)["marks"].([]interface{})
+			require.Len(t, marks, 1, "safe href %q must be preserved", href)
+		}
+	})
+}
+
+func TestSanitize_ImageSrc(t *testing.T) {
+	imageDoc := func(src string) *BlockDocV1 {
+		return &BlockDocV1{
+			DocVersion:  1,
+			BlocksOrder: []string{"img"},
+			Blocks: map[string]interface{}{
+				"img": map[string]interface{}{
+					"id": "img", "type": "image", "version": 1,
+					"attrs": map[string]interface{}{"src": src, "alt": "x"},
+				},
+			},
+		}
+	}
+	srcOf := func(doc *BlockDocV1) string {
+		return doc.Blocks["img"].(map[string]interface{})["attrs"].(map[string]interface{})["src"].(string)
+	}
+
+	t.Run("blanks javascript: and data: srcs", func(t *testing.T) {
+		for _, src := range []string{"javascript:alert(1)", "data:text/html,<script>alert(1)</script>"} {
+			doc := imageDoc(src)
+			doc.sanitize()
+			require.Equal(t, "", srcOf(doc), "unsafe src %q must be blanked", src)
+		}
+	})
+
+	t.Run("preserves http(s) and relative /uploads srcs", func(t *testing.T) {
+		for _, src := range []string{"https://cdn.example.com/a.png", "/uploads/media/a.png"} {
+			doc := imageDoc(src)
+			doc.sanitize()
+			require.Equal(t, src, srcOf(doc), "safe src %q must be preserved", src)
+		}
+	})
+}
+
+func TestSanitize_DangerousNodesAndAttrs(t *testing.T) {
+	t.Run("drops script/iframe child nodes", func(t *testing.T) {
+		doc := &BlockDocV1{
+			DocVersion:  1,
+			BlocksOrder: []string{"b1"},
+			Blocks: map[string]interface{}{
+				"b1": map[string]interface{}{
+					"id": "b1", "type": "paragraph", "version": 1,
+					"attrs": map[string]interface{}{
+						"pm": map[string]interface{}{
+							"type": "paragraph",
+							"content": []interface{}{
+								map[string]interface{}{"type": "text", "text": "ok"},
+								map[string]interface{}{"type": "script", "content": []interface{}{map[string]interface{}{"type": "text", "text": "alert(1)"}}},
+								map[string]interface{}{"type": "iframe"},
+							},
+						},
+					},
+				},
+			},
+		}
+		doc.sanitize()
+		b := doc.Blocks["b1"].(map[string]interface{})
+		content := b["attrs"].(map[string]interface{})["pm"].(map[string]interface{})["content"].([]interface{})
+		require.Len(t, content, 1, "script and iframe nodes must be dropped")
+		require.Equal(t, "text", content[0].(map[string]interface{})["type"])
+	})
+
+	t.Run("strips on* handler attributes from node and mark attrs", func(t *testing.T) {
+		marks := []interface{}{
+			map[string]interface{}{"type": "bold", "attrs": map[string]interface{}{"onmouseover": "alert(1)"}},
+		}
+		nodeAttrs := map[string]interface{}{"textAlign": "left", "onclick": "alert(1)", "ONLOAD": "x"}
+		doc := paragraphWithText("hi", marks, nodeAttrs)
+		doc.sanitize()
+
+		node := firstTextNode(t, doc)
+		pm := doc.Blocks["b1"].(map[string]interface{})["attrs"].(map[string]interface{})["pm"].(map[string]interface{})
+		gotNodeAttrs := pm["attrs"].(map[string]interface{})
+		require.Equal(t, "left", gotNodeAttrs["textAlign"], "legit attrs preserved")
+		require.NotContains(t, gotNodeAttrs, "onclick")
+		require.NotContains(t, gotNodeAttrs, "ONLOAD")
+
+		markAttrs := node["marks"].([]interface{})[0].(map[string]interface{})["attrs"].(map[string]interface{})
+		require.NotContains(t, markAttrs, "onmouseover")
+	})
+}
+
+func TestSanitize_HighlightColor(t *testing.T) {
+	highlight := func(color string) []interface{} {
+		return []interface{}{map[string]interface{}{"type": "highlight", "attrs": map[string]interface{}{"color": color}}}
+	}
+	colorOf := func(doc *BlockDocV1) (string, bool) {
+		attrs := firstTextNode(t, doc)["marks"].([]interface{})[0].(map[string]interface{})["attrs"].(map[string]interface{})
+		c, ok := attrs["color"].(string)
+		return c, ok
+	}
+
+	t.Run("drops unsafe color values", func(t *testing.T) {
+		doc := paragraphWithText("x", highlight("red; background:url(data:image/svg+xml,<svg onload=alert(1)>)"), nil)
+		doc.sanitize()
+		_, ok := colorOf(doc)
+		require.False(t, ok, "unsafe color must be removed")
+	})
+
+	t.Run("keeps safe color values", func(t *testing.T) {
+		for _, c := range []string{"#ffeb3b", "rgb(255, 235, 59)", "yellow"} {
+			doc := paragraphWithText("x", highlight(c), nil)
+			doc.sanitize()
+			got, ok := colorOf(doc)
+			require.True(t, ok, "safe color %q must be kept", c)
+			require.Equal(t, c, got)
+		}
+	})
+}
+
+func TestSanitize_SafeContentUnchanged(t *testing.T) {
+	doc := paragraphWithText("hello world", linkMark("https://example.com"), map[string]interface{}{"textAlign": "center"})
+	doc.sanitize()
+	node := firstTextNode(t, doc)
+	require.Equal(t, "hello world", node["text"])
+	require.Len(t, node["marks"].([]interface{}), 1)
+}
+
+func TestIsSafeURL(t *testing.T) {
+	require.True(t, isSafeURL("", safeHrefSchemes))
+	require.True(t, isSafeURL("/uploads/x.png", safeImageSchemes))
+	require.True(t, isSafeURL("https://x.com", safeImageSchemes))
+	require.False(t, isSafeURL("javascript:alert(1)", safeHrefSchemes))
+	require.False(t, isSafeURL("data:text/html,x", safeImageSchemes))
+	require.False(t, isSafeURL("JavaScript:alert(1)", safeHrefSchemes), "scheme check is case-insensitive")
+}
+
+func TestIsSafeColor(t *testing.T) {
+	require.True(t, isSafeColor("#fff"))
+	require.True(t, isSafeColor("rgba(0,0,0,.5)"))
+	require.True(t, isSafeColor("transparent"))
+	require.False(t, isSafeColor("red;url(x)"))
+	require.False(t, isSafeColor("url(javascript:alert(1))"))
+}

--- a/api/post_blocks_test.go
+++ b/api/post_blocks_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -321,6 +322,44 @@ func TestUpdatePostBlocksAPI(t *testing.T) {
 			tc.checkResponse(recorder)
 		})
 	}
+}
+
+// TestUpdatePostBlocksSanitizesOnSave verifies the sanitizer (#188) runs in the
+// save path: a javascript: link href in the posted block doc must be stripped
+// before the document is persisted.
+func TestUpdatePostBlocksSanitizesOnSave(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	store := mockdb.NewMockStore(ctrl)
+
+	body := `{"doc":{"doc_version":1,"blocks_order":["b1"],"blocks":{"b1":{"id":"b1","type":"paragraph","version":1,"attrs":{"pm":{"type":"paragraph","content":[{"type":"text","text":"click","marks":[{"type":"link","attrs":{"href":"javascript:alert(1)"}}]}]}}}}}}`
+
+	store.EXPECT().
+		UpdatePostBlocksIfRevisionMatches(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, params db.UpdatePostBlocksIfRevisionMatchesParams) (db.UpdatePostBlocksIfRevisionMatchesRow, error) {
+			require.NotContains(t, string(params.BlockDoc), "javascript:",
+				"sanitizer must strip the javascript: href before persisting")
+			return db.UpdatePostBlocksIfRevisionMatchesRow{Content: params.BlockDoc, Revision: 2}, nil
+		}).
+		Times(1)
+
+	// syncPostMediaAssociations runs after the save; no images → just lists media.
+	store.EXPECT().
+		GetMediaByPostWithOrder(gomock.Any(), int64(1)).
+		Return([]db.GetMediaByPostWithOrderRow{}, nil).
+		Times(1)
+
+	server := newTestServer(t, store)
+	recorder := httptest.NewRecorder()
+
+	request, err := http.NewRequest(http.MethodPut, "/api/v1/posts/1/blocks", bytes.NewReader([]byte(body)))
+	require.NoError(t, err)
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("If-Match", "1")
+	addAuthorization(t, request, server.tokenMaker, authorizationTypeBearer, 1, "testuser", time.Minute)
+
+	server.router.ServeHTTP(recorder, request)
+	require.Equal(t, http.StatusOK, recorder.Code)
 }
 
 func TestPublishPostAPI(t *testing.T) {

--- a/web/gl-admin/components/editor/utils/extensions.ts
+++ b/web/gl-admin/components/editor/utils/extensions.ts
@@ -49,6 +49,9 @@ const extensions = ({ collabProvider, maxChars, placeholder, setUrl, setIsLinkMo
       Link.configure({
         autolink: true,
         openOnClick: false,
+        // Reject non-http(s) protocols at the input layer (#188). `protocols` limits
+        // autolink/paste schemes; `validate` is the stronger guard for typed hrefs.
+        protocols: ["http", "https"],
         validate: (href) => /^https?:\/\//.test(href),
         HTMLAttributes: {
           class: "editor-link",

--- a/web/src/components/blocks/image/ImageBlock.tsx
+++ b/web/src/components/blocks/image/ImageBlock.tsx
@@ -1,9 +1,10 @@
 import React from "react"
 import type { BlockComponentProps } from "../types"
+import { safeImageSrc } from "../utils/safeUrl"
 
 const ImageBlock: React.FC<BlockComponentProps> = ({ block }) => {
   const attrs = block.attrs as Record<string, unknown>
-  const src = (attrs?.src as string) || ""
+  const src = safeImageSrc(attrs?.src as string | undefined)
   const alt = (attrs?.alt as string) || ""
   const title = attrs?.title as string | undefined
 

--- a/web/src/components/blocks/utils/contentRenderer.tsx
+++ b/web/src/components/blocks/utils/contentRenderer.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import type { PMNode } from "../types"
 import type { Block } from "@gl-admin/lib/blocks-spec"
+import { safeHref, safeCssColor } from "./safeUrl"
 
 /**
  * Render a single text node with its marks (bold, italic, link, code, etc.)
@@ -34,7 +35,7 @@ export function renderTextNode(node: PMNode, index: number): React.ReactNode {
           content = (
             <a
               key={`link-${index}`}
-              href={(mark.attrs?.href as string) || "#"}
+              href={safeHref(mark.attrs?.href as string | undefined) ?? "#"}
               target={(mark.attrs?.target as string) || undefined}
               rel={mark.attrs?.target === "_blank" ? "noopener noreferrer" : undefined}
             >
@@ -44,7 +45,7 @@ export function renderTextNode(node: PMNode, index: number): React.ReactNode {
           break
         case "highlight":
           content = (
-            <mark key={`highlight-${index}`} style={{ backgroundColor: mark.attrs?.color as string }}>
+            <mark key={`highlight-${index}`} style={{ backgroundColor: safeCssColor(mark.attrs?.color as string | undefined) }}>
               {content}
             </mark>
           )

--- a/web/src/components/blocks/utils/safeUrl.ts
+++ b/web/src/components/blocks/utils/safeUrl.ts
@@ -1,0 +1,62 @@
+/**
+ * URL/CSS sanitization helpers for the public Block Spec v1 renderer (issue #188).
+ *
+ * Defence in depth alongside the server-side sanitizer in `api/post_blocks_sanitize.go`:
+ * the server cleans content on save, but content already stored before the sanitizer
+ * existed is only made safe here, at render time. React/Astro escape text and attribute
+ * VALUES, but they do NOT block dangerous URL schemes (javascript:) or CSS values — these
+ * helpers do. Keep the logic in sync with the Go sanitizer.
+ */
+
+const SAFE_HREF_SCHEMES = new Set(["http", "https", "mailto", "tel"])
+const SAFE_IMAGE_SCHEMES = new Set(["http", "https"])
+
+// Conservative CSS color allowlist: hex / rgb(a) / hsl(a) / named color. Rejects
+// anything containing url(), semicolons, etc.
+const SAFE_COLOR_RE = /^(#[0-9a-fA-F]{3,8}|[a-zA-Z]+|(?:rgb|rgba|hsl|hsla)\([0-9.,%\s/]+\))$/
+
+// NUL / TAB / LF / CR are stripped by browsers before URL parsing, so they can smuggle
+// a scheme past a naive check (e.g. "java<TAB>script:"). Reject any URL containing them.
+// (A literal space is NOT included — it is not a smuggling vector and legitimate paths
+// like "/uploads/my image.png" can contain spaces.)
+function hasUnsafeControlChars(s: string): boolean {
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i)
+    if (c === 0 || c === 9 || c === 10 || c === 13) return true
+  }
+  return false
+}
+
+/** Returns the lowercased URL scheme, or null for a relative URL (no scheme). */
+function schemeOf(s: string): string | null {
+  const m = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(s)
+  return m ? m[1].toLowerCase() : null
+}
+
+function isSafeUrl(raw: string | undefined | null, allowed: Set<string>): boolean {
+  if (raw == null) return true
+  const s = raw.trim()
+  if (s === "") return true
+  if (hasUnsafeControlChars(s)) return false
+  const scheme = schemeOf(s)
+  if (scheme === null) return true // relative URL (/uploads/x, #anchor, ?q=1, …)
+  return allowed.has(scheme)
+}
+
+/** Safe href for a link, or `undefined` (caller should fall back to "#"). */
+export function safeHref(href: string | undefined | null): string | undefined {
+  return isSafeUrl(href, SAFE_HREF_SCHEMES) ? (href ?? undefined) : undefined
+}
+
+/** Safe image src, or "" when the URL scheme is not allowed. */
+export function safeImageSrc(src: string | undefined | null): string {
+  return isSafeUrl(src, SAFE_IMAGE_SCHEMES) ? (src ?? "") : ""
+}
+
+/** Safe CSS color value, or `undefined` when it isn't a recognised safe token. */
+export function safeCssColor(color: string | undefined | null): string | undefined {
+  if (color == null) return undefined
+  const c = color.trim()
+  if (c === "") return undefined
+  return SAFE_COLOR_RE.test(c) ? color : undefined
+}


### PR DESCRIPTION
﻿Closes #188. Server-side sanitization of Block Spec v1 documents + render-time hardening to prevent **stored XSS**. Branched off `main` — independent and mergeable on its own.

## The vectors (confirmed)

Block content is structured ProseMirror JSON rendered to HTML on public Astro SSR pages. React/Astro already escape text + attribute *values* and there's no `{...attrs}` spreading or `set:html` on user content in the active path — so the real, unescaped vectors are:

- **Link `href`** (`contentRenderer.tsx`) — a `javascript:` href executes on click. **Critical.**
- **Image `src`** (`ImageBlock.tsx`) — `javascript:`/`data:` protocols.
- **Highlight `color`** (`contentRenderer.tsx`) — CSS-value injection (e.g. `url(data:image/svg+xml,…)`).
- Defence-in-depth: `on*` handler attrs and `script`/`iframe`/`object`/`embed` node types.

## Two layers (they protect different things)

### 1. Server-side sanitizer on save — `api/post_blocks_sanitize.go`
A recursive walker over the untyped block tree (no HTML-sanitizer lib — the content is a JSON tree, not an HTML string). Hooked into `updatePostBlocks` after `deduplicateBlocksOrder`; `publishPost` reads the already-sanitized working copy. **Sanitize-in-place, never rejects the save** — the payload is stripped before it reaches the DB:
- link mark with unsafe href → removed (text kept); image src with unsafe scheme → blanked; unsafe highlight color → dropped; `on*` attrs stripped; dangerous node types dropped.

### 2. Render-time hardening — `web/src/components/blocks/utils/safeUrl.ts`
Protects content **already in the DB** (the server pass only cleans new saves) and guarantees safety at render. Pure `safeHref` / `safeImageSrc` / `safeCssColor`, applied in `contentRenderer.tsx` (href + color) and `ImageBlock.tsx` (src). Logic mirrors the Go sanitizer.

### 3. Input-side
Editor `Link` extension already enforced http(s) via `validate`; added `protocols: ["http","https"]` for completeness. Image input is via the MediaSelector (`/uploads`), not free-typed.

## Tests
- **Go (covers the security ACs):** `api/post_blocks_sanitize_test.go` — table tests for href/src/color/on*/dangerous-nodes + safe-content-unchanged + URL/color helper tests; plus a handler-level test (`TestUpdatePostBlocksSanitizesOnSave`) asserting the **persisted bytes** from `updatePostBlocks` contain no `javascript:`.
- **Frontend helper unit tests** are deferred until the Vitest infra (#202/#203) merges to `main`; the security-critical path is covered by the Go tests here.

## Acceptance criteria
- [x] Block doc save sanitizes the tree before persisting
- [x] No `set:html` on user content (the only block renderer path builds JSX from structured data; `TipTapContent.astro` is legacy/unused — flagged for removal)
- [x] Link/image reject `javascript:`/`data:` (server strip + render-time + input `validate`/`protocols`)
- [x] Test: a script node / `on*` attr is stripped on save
- [x] Test: a `javascript:` href is removed on save

## Test plan
- [x] `go test ./api/...` green (incl. new sanitizer + handler tests)
- [ ] Manual: POST a crafted block doc with a `javascript:` link / bad image src to `PUT /api/v1/posts/:id/blocks`, reload the public page → link inert, image empty, no script executes; normal content still renders.