### PR TITLE
security: prevent last-admin lockout on user demotion and deletion

### DIFF
--- a/api/user_test.go
+++ b/api/user_test.go
@@ -574,6 +574,35 @@ func TestUpdateUserAPI(t *testing.T) {
 			},
 		},
 		{
+			name:   "InternalErrorAdminCountOnDemote",
+			userID: user.ID + 50,
+			body: gin.H{
+				"role": "contributor",
+			},
+			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
+				addAuthorization(t, request, tokenMaker, authorizationTypeBearer, user.ID+50, "admin_caller", time.Minute)
+			},
+			buildStubs: func(store *mockdb.MockStore) {
+				adminCaller := randomUserNew()
+				adminCaller.ID = user.ID + 50
+				adminCaller.Role = RoleAdmin
+				store.EXPECT().
+					GetUser(gomock.Any(), gomock.Eq(adminCaller.ID)).
+					Times(2).
+					Return(adminCaller, nil)
+				store.EXPECT().
+					CountUsersByRole(gomock.Any(), gomock.Eq(RoleAdmin)).
+					Times(1).
+					Return(int64(0), fmt.Errorf("connection refused"))
+				store.EXPECT().
+					UpdateUserTx(gomock.Any(), gomock.Any()).
+					Times(0)
+			},
+			checkResponse: func(recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusInternalServerError, recorder.Code)
+			},
+		},
+		{
 			name:   "OK_DemoteAdminWhenAnotherExists",
 			userID: user.ID + 51,
 			body: gin.H{
@@ -872,6 +901,30 @@ func TestDeleteUserAPI(t *testing.T) {
 			},
 			checkResponse: func(recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusConflict, recorder.Code)
+			},
+		},
+		{
+			name:   "InternalErrorAdminCountOnDelete",
+			userID: adminUser.ID,
+			body:   gin.H{},
+			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
+				addAuthorization(t, request, tokenMaker, authorizationTypeBearer, adminUser.ID, adminUser.Username, time.Minute)
+			},
+			buildStubs: func(store *mockdb.MockStore) {
+				store.EXPECT().
+					GetUser(gomock.Any(), gomock.Eq(adminUser.ID)).
+					Times(2).
+					Return(adminUser, nil)
+				store.EXPECT().
+					CountUsersByRole(gomock.Any(), gomock.Eq(RoleAdmin)).
+					Times(1).
+					Return(int64(0), fmt.Errorf("connection refused"))
+				store.EXPECT().
+					DeleteUserTx(gomock.Any(), gomock.Any()).
+					Times(0)
+			},
+			checkResponse: func(recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusInternalServerError, recorder.Code)
 			},
 		},
 		{

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -544,6 +544,76 @@ func TestUpdateUserAPI(t *testing.T) {
 			},
 		},
 		{
+			name:   "ConflictDemoteLastAdmin",
+			userID: user.ID + 50,
+			body: gin.H{
+				"role": "contributor",
+			},
+			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
+				addAuthorization(t, request, tokenMaker, authorizationTypeBearer, user.ID+50, "admin_caller", time.Minute)
+			},
+			buildStubs: func(store *mockdb.MockStore) {
+				adminCaller := randomUserNew()
+				adminCaller.ID = user.ID + 50
+				adminCaller.Role = "admin"
+				// Caller check + target fetch hit the same (sole admin) row
+				store.EXPECT().
+					GetUser(gomock.Any(), gomock.Eq(adminCaller.ID)).
+					Times(2).
+					Return(adminCaller, nil)
+				store.EXPECT().
+					CountUsersByRole(gomock.Any(), gomock.Eq(RoleAdmin)).
+					Times(1).
+					Return(int64(1), nil)
+				store.EXPECT().
+					UpdateUserTx(gomock.Any(), gomock.Any()).
+					Times(0)
+			},
+			checkResponse: func(recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusConflict, recorder.Code)
+			},
+		},
+		{
+			name:   "OK_DemoteAdminWhenAnotherExists",
+			userID: user.ID + 51,
+			body: gin.H{
+				"role": "editor",
+			},
+			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
+				addAuthorization(t, request, tokenMaker, authorizationTypeBearer, user.ID+50, "admin_caller", time.Minute)
+			},
+			buildStubs: func(store *mockdb.MockStore) {
+				adminCaller := randomUserNew()
+				adminCaller.ID = user.ID + 50
+				adminCaller.Role = "admin"
+				otherAdmin := randomUserNew()
+				otherAdmin.ID = user.ID + 51
+				otherAdmin.Role = "admin"
+				store.EXPECT().
+					GetUser(gomock.Any(), gomock.Eq(adminCaller.ID)).
+					Times(1).
+					Return(adminCaller, nil)
+				store.EXPECT().
+					GetUser(gomock.Any(), gomock.Eq(otherAdmin.ID)).
+					Times(1).
+					Return(otherAdmin, nil)
+				store.EXPECT().
+					CountUsersByRole(gomock.Any(), gomock.Eq(RoleAdmin)).
+					Times(1).
+					Return(int64(2), nil)
+
+				demoted := otherAdmin
+				demoted.Role = "editor"
+				store.EXPECT().
+					UpdateUserTx(gomock.Any(), gomock.Any()).
+					Times(1).
+					Return(db.UpdateUserTxResult{User: demoted}, nil)
+			},
+			checkResponse: func(recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusOK, recorder.Code)
+			},
+		},
+		{
 			name:   "ForbiddenUpdateOtherUser",
 			userID: user.ID + 99,
 			body: gin.H{
@@ -777,6 +847,63 @@ func TestDeleteUserAPI(t *testing.T) {
 			},
 			checkResponse: func(recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusNotFound, recorder.Code)
+			},
+		},
+		{
+			name:   "ConflictDeleteLastAdmin",
+			userID: adminUser.ID,
+			body:   gin.H{},
+			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
+				addAuthorization(t, request, tokenMaker, authorizationTypeBearer, adminUser.ID, adminUser.Username, time.Minute)
+			},
+			buildStubs: func(store *mockdb.MockStore) {
+				// Middleware caller check + handler target fetch on the sole admin
+				store.EXPECT().
+					GetUser(gomock.Any(), gomock.Eq(adminUser.ID)).
+					Times(2).
+					Return(adminUser, nil)
+				store.EXPECT().
+					CountUsersByRole(gomock.Any(), gomock.Eq(RoleAdmin)).
+					Times(1).
+					Return(int64(1), nil)
+				store.EXPECT().
+					DeleteUserTx(gomock.Any(), gomock.Any()).
+					Times(0)
+			},
+			checkResponse: func(recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusConflict, recorder.Code)
+			},
+		},
+		{
+			name:   "OK_DeleteAdminWhenAnotherExists",
+			userID: adminUser.ID + 1,
+			body:   gin.H{},
+			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
+				addAuthorization(t, request, tokenMaker, authorizationTypeBearer, adminUser.ID, adminUser.Username, time.Minute)
+			},
+			buildStubs: func(store *mockdb.MockStore) {
+				secondAdmin := randomUserNew()
+				secondAdmin.ID = adminUser.ID + 1
+				secondAdmin.Role = "admin"
+				store.EXPECT().
+					GetUser(gomock.Any(), gomock.Eq(adminUser.ID)).
+					Times(1).
+					Return(adminUser, nil)
+				store.EXPECT().
+					GetUser(gomock.Any(), gomock.Eq(secondAdmin.ID)).
+					Times(1).
+					Return(secondAdmin, nil)
+				store.EXPECT().
+					CountUsersByRole(gomock.Any(), gomock.Eq(RoleAdmin)).
+					Times(1).
+					Return(int64(2), nil)
+				store.EXPECT().
+					DeleteUserTx(gomock.Any(), gomock.Eq(secondAdmin.ID)).
+					Times(1).
+					Return(nil)
+			},
+			checkResponse: func(recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusOK, recorder.Code)
 			},
 		},
 		{

--- a/api/users_handlers_write.go
+++ b/api/users_handlers_write.go
@@ -167,6 +167,10 @@ func (server *Server) updateUser(c *gin.Context) {
 
 	// Last-admin guard: demoting the only remaining admin would leave the
 	// site with no account able to manage users, themes, or settings.
+	// Known race: the count runs outside the update/delete transaction, so
+	// two concurrent admin-removing operations (demote+demote, demote+delete)
+	// can each see count=2 and end at zero admins. Accepted until a
+	// transactional guard (count FOR UPDATE inside the Tx) is warranted.
 	demotingAdmin := req.Role != "" &&
 		strings.EqualFold(existingUser.Role, RoleAdmin) &&
 		!strings.EqualFold(req.Role, RoleAdmin)
@@ -284,6 +288,7 @@ func (server *Server) deleteUser(c *gin.Context) {
 
 	// Last-admin guard: deleting the only remaining admin would leave the
 	// site with no account able to manage users, themes, or settings.
+	// Same non-transactional race as the demote guard in updateUser above.
 	if strings.EqualFold(targetUser.Role, RoleAdmin) {
 		adminCount, err := server.store.CountUsersByRole(c.Request.Context(), RoleAdmin)
 		if err != nil {

--- a/api/users_handlers_write.go
+++ b/api/users_handlers_write.go
@@ -116,7 +116,7 @@ func (server *Server) createUser(c *gin.Context) {
 //   - 401 Unauthorized: Invalid authentication token
 //   - 403 Forbidden: Not the account owner, or non-admin changing a role
 //   - 404 Not Found: User does not exist
-//   - 409 Conflict: Username or email already exists
+//   - 409 Conflict: Username or email already exists, or demoting the last admin
 //   - 500 Internal Server Error: Database transaction failure
 func (server *Server) updateUser(c *gin.Context) {
 	idParam := c.Param("id")
@@ -163,6 +163,23 @@ func (server *Server) updateUser(c *gin.Context) {
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get user"})
 		return
+	}
+
+	// Last-admin guard: demoting the only remaining admin would leave the
+	// site with no account able to manage users, themes, or settings.
+	demotingAdmin := req.Role != "" &&
+		strings.EqualFold(existingUser.Role, RoleAdmin) &&
+		!strings.EqualFold(req.Role, RoleAdmin)
+	if demotingAdmin {
+		adminCount, err := server.store.CountUsersByRole(c.Request.Context(), RoleAdmin)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to verify admin count"})
+			return
+		}
+		if adminCount <= 1 {
+			c.JSON(http.StatusConflict, gin.H{"error": "cannot demote the last admin"})
+			return
+		}
 	}
 
 	// Prepare update parameters with existing values as defaults
@@ -238,6 +255,7 @@ func (server *Server) updateUser(c *gin.Context) {
 //   - 401 Unauthorized: Invalid authentication token
 //   - 403 Forbidden: Insufficient permissions (non-admin)
 //   - 404 Not Found: User does not exist
+//   - 409 Conflict: Target is the last remaining admin
 //   - 500 Internal Server Error: Database transaction failure
 func (server *Server) deleteUser(c *gin.Context) {
 	idParam := c.Param("id")
@@ -254,7 +272,7 @@ func (server *Server) deleteUser(c *gin.Context) {
 	}
 
 	// Verify user exists before attempting deletion
-	_, err = server.store.GetUser(c.Request.Context(), id)
+	targetUser, err := server.store.GetUser(c.Request.Context(), id)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
@@ -262,6 +280,20 @@ func (server *Server) deleteUser(c *gin.Context) {
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get user"})
 		return
+	}
+
+	// Last-admin guard: deleting the only remaining admin would leave the
+	// site with no account able to manage users, themes, or settings.
+	if strings.EqualFold(targetUser.Role, RoleAdmin) {
+		adminCount, err := server.store.CountUsersByRole(c.Request.Context(), RoleAdmin)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to verify admin count"})
+			return
+		}
+		if adminCount <= 1 {
+			c.JSON(http.StatusConflict, gin.H{"error": "cannot delete the last admin"})
+			return
+		}
 	}
 
 	if req.TransferToID != nil {

--- a/api/users_handlers_write.go
+++ b/api/users_handlers_write.go
@@ -166,7 +166,8 @@ func (server *Server) updateUser(c *gin.Context) {
 	}
 
 	// Last-admin guard: demoting the only remaining admin would leave the
-	// site with no account able to manage users, themes, or settings.
+	// site with no account able to manage users, themes, settings, or
+	// post types.
 	// Known race: the count runs outside the update/delete transaction, so
 	// two concurrent admin-removing operations (demote+demote, demote+delete)
 	// can each see count=2 and end at zero admins. Accepted until a
@@ -287,7 +288,8 @@ func (server *Server) deleteUser(c *gin.Context) {
 	}
 
 	// Last-admin guard: deleting the only remaining admin would leave the
-	// site with no account able to manage users, themes, or settings.
+	// site with no account able to manage users, themes, settings, or
+	// post types.
 	// Same non-transactional race as the demote guard in updateUser above.
 	if strings.EqualFold(targetUser.Role, RoleAdmin) {
 		adminCount, err := server.store.CountUsersByRole(c.Request.Context(), RoleAdmin)

--- a/db/mock/store.go
+++ b/db/mock/store.go
@@ -246,6 +246,21 @@ func (mr *MockStoreMockRecorder) CountTotalUsers(arg0 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountTotalUsers", reflect.TypeOf((*MockStore)(nil).CountTotalUsers), arg0)
 }
 
+// CountUsersByRole mocks base method.
+func (m *MockStore) CountUsersByRole(arg0 context.Context, arg1 string) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountUsersByRole", arg0, arg1)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountUsersByRole indicates an expected call of CountUsersByRole.
+func (mr *MockStoreMockRecorder) CountUsersByRole(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountUsersByRole", reflect.TypeOf((*MockStore)(nil).CountUsersByRole), arg0, arg1)
+}
+
 // CreateMedia mocks base method.
 func (m *MockStore) CreateMedia(arg0 context.Context, arg1 db.CreateMediaParams) (db.Medium, error) {
 	m.ctrl.T.Helper()

--- a/db/query/users.sql
+++ b/db/query/users.sql
@@ -85,3 +85,7 @@ WHERE user_id = $1;
 
 -- name: CountTotalUsers :one
 SELECT COUNT(*) AS total FROM users;
+
+-- name: CountUsersByRole :one
+SELECT COUNT(*) AS total FROM users
+WHERE lower(role) = lower(@role);

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -30,6 +30,7 @@ type Querier interface {
 	CountTotalPosts(ctx context.Context) (int64, error)
 	CountTotalSessions(ctx context.Context) (int64, error)
 	CountTotalUsers(ctx context.Context) (int64, error)
+	CountUsersByRole(ctx context.Context, role string) (int64, error)
 	CreateMedia(ctx context.Context, arg CreateMediaParams) (Medium, error)
 	CreatePostMedia(ctx context.Context, arg CreatePostMediaParams) (PostMedium, error)
 	CreatePostMeta(ctx context.Context, arg CreatePostMetaParams) (PostMetum, error)

--- a/db/sqlc/user_test.go
+++ b/db/sqlc/user_test.go
@@ -95,6 +95,19 @@ func TestCreateUser(t *testing.T) {
 	require.NotEmpty(t, user)
 }
 
+func TestCountUsersByRole(t *testing.T) {
+	user := createTestUser(t) // role "contributor"
+
+	count, err := testQueries.CountUsersByRole(context.Background(), user.Role)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, count, int64(1))
+
+	// The comparison is case-insensitive on both sides
+	upper, err := testQueries.CountUsersByRole(context.Background(), strings.ToUpper(user.Role))
+	require.NoError(t, err)
+	require.Equal(t, count, upper)
+}
+
 func TestGetUser(t *testing.T) {
 	user1 := createTestUser(t)
 	user2, err := testQueries.GetUser(context.Background(), user1.ID)

--- a/db/sqlc/users.sql.go
+++ b/db/sqlc/users.sql.go
@@ -21,6 +21,18 @@ func (q *Queries) CountTotalUsers(ctx context.Context) (int64, error) {
 	return total, err
 }
 
+const countUsersByRole = `-- name: CountUsersByRole :one
+SELECT COUNT(*) AS total FROM users
+WHERE lower(role) = lower($1)
+`
+
+func (q *Queries) CountUsersByRole(ctx context.Context, role string) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countUsersByRole, role)
+	var total int64
+	err := row.Scan(&total)
+	return total, err
+}
+
 const createUser = `-- name: CreateUser :one
 INSERT INTO users (
     username,


### PR DESCRIPTION
Closes #209. Stacked on #208 (base: `187-rbac-enforcement`) - only the last-admin commit is in this diff; retarget to `main` after #208 merges.  ## What this does  #208 made user, theme, settings, and post-type management admin-only - but nothing stopped the **final admin** from removing their own access. An admin could demote themselves (`PUT /users/:id` with a non-admin `role`) or delete the only admin account (`DELETE /users/:id`), leaving the site with no account able to administer it. Recovery required direct SQL or the debug-mode default-user seeder.  Both handlers in `api/users_handlers_write.go` now guard the operation:  - **`updateUser`**: when the request moves an admin target OFF the admin role, count remaining admins; if the target is the last one -> `409 Conflict` (`"cannot demote the last admin"`). - **`deleteUser`**: same guard when the delete target is an admin -> `409 Conflict` (`"cannot delete the last admin"`). - Demoting or deleting an admin while another admin exists is unaffected. Role comparison stays case-insensitive end to end (new `CountUsersByRole` sqlc query compares `lower(role)`).  `409` rather than `403` because the caller IS authorized - the operation conflicts with system state, and the explicit message tells the admin exactly why it was refused.  **Known limitation (documented in the code):** the admin count runs outside the mutation transaction, so any pair of concurrent admin-removing operations (demote+demote, demote+delete) can each observe count=2 and end at zero admins - not just concurrent demotes. Accepted for now; the structural fix is a count with FOR UPDATE semantics inside UpdateUserTx/DeleteUserTx if it ever matters in practice.  ## Changes  - `db/query/users.sql` + regenerated `db/sqlc/` and `db/mock/store.go`: new `CountUsersByRole` query (sqlc v1.29.0 / mockgen v1.6.0, matching committed generator versions - zero churn outside the new method) - `api/users_handlers_write.go`: last-admin guards in `updateUser` / `deleteUser`, doc comments updated with the 409 responses  ## Testing  - `go test ./...` green, including `db/sqlc` against real Postgres - New mock cases: demote last admin -> 409; delete last admin -> 409; demote/delete an admin while a second admin exists -> 200; existing update/delete/403 cases unchanged - New real-DB test for `CountUsersByRole` incl. case-insensitivity - Live check against the dev stack: demoting `testadmin` while other admins exist succeeds and restores cleanly (guard path executes the real query)  ## Manual testing (for the reviewer)  The dev DB currently has three admins (`admin`, `LuanK`, `testadmin` - password `123456` for `admin`/`testadmin`). To see the 409 you need to get down to one admin:  ```bash TOK=$(curl -s -X POST http://localhost:8080/api/v1/auth/login \   -H "Content-Type: application/json" \   -d '{"username":"admin","password":"123456"}' | jq -r .access_token)  # Demote the other admins first (allowed while >1 admin remains), e.g. testadmin (id 1812): curl -s -X PUT http://localhost:8080/api/v1/users/1812 \   -H "Authorization: Bearer $TOK" -H "Content-Type: application/json" \   -d '{"role":"editor"}'  # ...repeat for any other admin account, then try to demote yourself (admin is id 1) -> 409: curl -s -w "\n%{http_code}\n" -X PUT http://localhost:8080/api/v1/users/1 \   -H "Authorization: Bearer $TOK" -H "Content-Type: application/json" \   -d '{"role":"contributor"}'  # And deleting yourself as the last admin -> 409: curl -s -w "\n%{http_code}\n" -X DELETE http://localhost:8080/api/v1/users/1 \   -H "Authorization: Bearer $TOK" -H "Content-Type: application/json" -d '{}'  # Restore the demoted admins afterwards: curl -s -X PUT http://localhost:8080/api/v1/users/1812 \   -H "Authorization: Bearer $TOK" -H "Content-Type: application/json" \   -d '{"role":"admin"}' ```  🤖 Generated with [Claude Code](https://claude.com/claude-code)